### PR TITLE
Feat: 자격증 OCR 업로드 프론트 연동

### DIFF
--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -11,7 +11,7 @@ import {
 const quickMenus = [
   {
     title: "내 정보 관리",
-    description: "회원 정보와 연락처를 확인하고 수정할 수 있습니다.",
+    description: "회원 정보와 이용 현황을 확인하고 필요한 내용을 확인합니다.",
     icon: User,
   },
   {
@@ -21,7 +21,7 @@ const quickMenus = [
   },
   {
     title: "카드 이용내역",
-    description: "최근 결제 내역과 월별 사용 흐름을 빠르게 확인합니다.",
+    description: "최근 결제 내역과 상세 사용 흐름을 확인합니다.",
     icon: CreditCard,
   },
   {
@@ -32,18 +32,39 @@ const quickMenus = [
 ];
 
 const ocrSteps = [
-  "자격증 이미지 업로드",
+  "자격증 파일 업로드",
   "OCR 텍스트 추출",
   "자격증명 및 발급기관 확인",
   "우대 금리 적용 여부 안내",
 ];
 
+type UploadStatus = "idle" | "selected" | "uploading" | "completed" | "failed";
+
+type CertificateSubmissionResponse = {
+  submissionId: number;
+  filename: string;
+  contentType: string;
+  extractedText: string;
+  lines: string[];
+  lineCount: number;
+  verificationStatus: string;
+  submittedAt: string;
+};
+
+const API_BASE_URL = "http://localhost:9999";
+const DEFAULT_MEMBER_ID = "1";
+const DEFAULT_LOAN_ID = "1";
+const DEFAULT_CERTIFICATE_ID = "1";
+const NO_TEXT_DETECTED_MESSAGE =
+  "자격증 내용을 확인할 수 없습니다. 자격증 전체가 잘 보이는 이미지 또는 PDF를 업로드해 주세요.";
+
 export default function MyPage() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [uploadStatus, setUploadStatus] = useState<
-    "idle" | "selected" | "uploading" | "completed"
-  >("idle");
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [ocrResult, setOcrResult] =
+    useState<CertificateSubmissionResponse | null>(null);
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0] ?? null;
@@ -51,150 +72,211 @@ export default function MyPage() {
     if (!file) {
       setSelectedFile(null);
       setUploadStatus("idle");
+      setUploadError(null);
+      setOcrResult(null);
       return;
     }
 
     setSelectedFile(file);
     setUploadStatus("selected");
+    setUploadError(null);
+    setOcrResult(null);
   };
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
   };
 
-  const handleMockUpload = () => {
-    if (!selectedFile) return;
+  const handleUpload = async () => {
+    if (!selectedFile) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("memberId", DEFAULT_MEMBER_ID);
+    formData.append("loanId", DEFAULT_LOAN_ID);
+    formData.append("certificateId", DEFAULT_CERTIFICATE_ID);
+    formData.append("file", selectedFile);
 
     setUploadStatus("uploading");
+    setUploadError(null);
 
-    window.setTimeout(() => {
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/api/certificates/submissions`,
+        {
+          method: "POST",
+          body: formData,
+        },
+      );
+
+      if (!response.ok) {
+        const errorBody = (await response.json().catch(() => null)) as
+          | { message?: string }
+          | null;
+        const message = errorBody?.message ?? "자격증 업로드에 실패했습니다.";
+        throw new Error(
+          message.includes("No text detected from image")
+            ? NO_TEXT_DETECTED_MESSAGE
+            : message,
+        );
+      }
+
+      const result =
+        (await response.json()) as CertificateSubmissionResponse;
+      setOcrResult(result);
       setUploadStatus("completed");
-    }, 1200);
+    } catch (error) {
+      setUploadStatus("failed");
+      setUploadError(
+        error instanceof Error
+          ? error.message
+          : "알 수 없는 오류가 발생했습니다.",
+      );
+      setOcrResult(null);
+    }
   };
 
-  const statusText = {
-    idle: "아직 업로드된 파일이 없습니다. 파일을 선택하면 인증 준비 상태로 변경됩니다.",
-    selected: `선택한 파일: ${selectedFile?.name ?? ""}`,
-    uploading: "OCR 인증 요청을 준비하고 있습니다.",
-    completed: "파일 업로드가 완료되었습니다. 다음 단계에서 OCR 결과를 연결할 수 있습니다.",
+  const statusText: Record<UploadStatus, string> = {
+    idle: "아직 업로드한 파일이 없습니다. 파일을 선택하면 인증 준비 상태로 변경됩니다.",
+    selected: `선택된 파일: ${selectedFile?.name ?? ""}`,
+    uploading: "OCR 인증 요청을 전송하고 있습니다.",
+    completed: "파일 업로드와 OCR 연동이 완료되었습니다. 인증 결과를 확인해 주세요.",
+    failed: uploadError ?? "업로드 중 오류가 발생했습니다.",
   };
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-4 py-12">
+      <div className="mx-auto max-w-7xl px-4 py-12">
         <div className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="bg-white/20 backdrop-blur-md rounded-full p-3 shadow-lg border-2 border-white/30">
-              <User className="w-8 h-8 text-white" />
+          <div className="mb-4 flex items-center gap-3">
+            <div className="rounded-full border-2 border-white/30 bg-white/20 p-3 shadow-lg backdrop-blur-md">
+              <User className="h-8 w-8 text-white" />
             </div>
             <h1 className="text-4xl font-bold text-[#1F2937] drop-shadow-lg">
               고객님의 금융 정보를 한눈에 확인하세요
             </h1>
           </div>
-          <p className="text-xl text-[#475569] ml-16 drop-shadow-lg">
-            계좌, 대출, 카드, 자격증 인증 현황까지 마이페이지에서 바로 확인할 수 있습니다.
+          <p className="ml-16 text-xl text-[#475569] drop-shadow-lg">
+            계좌, 대출, 카드, 자격증 인증 현황까지 마이페이지에서 바로 확인할 수
+            있습니다.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
-          <section className="lg:col-span-2 bg-white/60 backdrop-blur-lg rounded-3xl p-8 shadow-2xl border-2 border-white/40">
-            <div className="flex justify-between items-start gap-6 mb-8">
+        <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <section className="lg:col-span-2 rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
+            <div className="mb-8 flex items-start justify-between gap-6">
               <div className="flex-1">
-                <div className="flex items-center gap-3 mb-4">
-                  <h2 className="text-2xl font-bold text-[#1F2937]">홍길동 님의 마이페이지</h2>
-                  <span className="bg-[#B7C9FF] text-[#1F2937] px-4 py-1 rounded-full text-sm font-semibold shadow-md">
+                <div className="mb-4 flex items-center gap-3">
+                  <h2 className="text-2xl font-bold text-[#1F2937]">
+                    나만의 마이페이지
+                  </h2>
+                  <span className="rounded-full bg-[#B7C9FF] px-4 py-1 text-sm font-semibold text-[#1F2937] shadow-md">
                     정상 이용중
                   </span>
                 </div>
 
                 <div className="mb-6">
-                  <div className="text-5xl font-bold text-[#4A67E8] mb-2">VIP CARE</div>
+                  <div className="mb-2 text-5xl font-bold text-[#4A67E8]">
+                    VIP CARE
+                  </div>
                   <p className="text-base text-[#475569]">
-                    맞춤 금융 서비스와 자격증 인증 기반 우대 혜택을 한 곳에서 관리해보세요.
+                    맞춤 금융 서비스와 자격증 인증 기반 우대 혜택을 한곳에서
+                    관리해보세요.
                   </p>
                 </div>
 
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-6">
+                <div className="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-3">
                   <div>
-                    <p className="text-sm text-[#64748B] mb-1">보유 계좌</p>
-                    <p className="font-bold text-[#1F2937] text-2xl">2개</p>
+                    <p className="mb-1 text-sm text-[#64748B]">보유 계좌</p>
+                    <p className="text-2xl font-bold text-[#1F2937]">2개</p>
                   </div>
                   <div>
-                    <p className="text-sm text-[#64748B] mb-1">이용 중 대출</p>
-                    <p className="font-bold text-[#1F2937] text-2xl">1건</p>
+                    <p className="mb-1 text-sm text-[#64748B]">이용 중 대출</p>
+                    <p className="text-2xl font-bold text-[#1F2937]">1건</p>
                   </div>
                   <div>
-                    <p className="text-sm text-[#64748B] mb-1">인증 상태</p>
-                    <p className="font-bold text-[#1F2937] text-2xl">심사 전</p>
+                    <p className="mb-1 text-sm text-[#64748B]">인증 상태</p>
+                    <p className="text-2xl font-bold text-[#1F2937]">심사 전</p>
                   </div>
                 </div>
 
-                <div className="flex flex-wrap gap-2 mb-6">
-                  <span className="bg-white text-[#334155] px-4 py-2 rounded-lg text-sm shadow-sm">
-                    예금/적금 현황 확인
+                <div className="mb-6 flex flex-wrap gap-2">
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
+                    입금/출금 현황 확인
                   </span>
-                  <span className="bg-white text-[#334155] px-4 py-2 rounded-lg text-sm shadow-sm">
-                    대출 금리 조회
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
+                    대출금리 조회
                   </span>
-                  <span className="bg-white text-[#334155] px-4 py-2 rounded-lg text-sm shadow-sm">
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
                     자격증 인증 진행 가능
                   </span>
                 </div>
               </div>
 
-              <div className="relative w-64 h-64 flex-shrink-0 hidden md:flex items-center justify-center">
-                <div className="absolute w-48 h-32 bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] shadow-2xl opacity-80 blur-sm"></div>
-                <div className="absolute w-40 h-28 bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] shadow-xl"></div>
+              <div className="relative hidden h-64 w-64 flex-shrink-0 items-center justify-center md:flex">
+                <div className="absolute h-32 w-48 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 opacity-80 shadow-2xl blur-sm"></div>
+                <div className="absolute h-28 w-40 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 shadow-xl"></div>
               </div>
             </div>
 
             <div className="flex gap-4">
-              <button className="flex-1 bg-white text-[#1F2937] py-4 rounded-xl font-bold text-center hover:bg-white/90 transition-all shadow-sm">
+              <button className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
                 내 정보 보기
               </button>
-              <button className="flex-1 bg-[#B7C9FF] text-[#1F2937] py-4 rounded-xl font-bold hover:bg-[#a7bcff] transition-all shadow-md">
+              <button className="flex-1 rounded-xl bg-[#B7C9FF] py-4 font-bold text-[#1F2937] shadow-md transition-all hover:bg-[#a7bcff]">
                 자격증 인증 시작
               </button>
             </div>
           </section>
 
           <div className="space-y-6">
-            <section className="bg-white/60 backdrop-blur-lg rounded-3xl p-6 shadow-2xl border-2 border-white/40">
-              <h3 className="text-xl font-bold text-[#1F2937] mb-4">대출 현황</h3>
-              <div className="text-3xl font-bold text-[#4A67E8] mb-4">연 3.2% 적용중</div>
-              <div className="space-y-2 mb-6 text-[#475569]">
-                <p>소비연동형 자동상환 대출</p>
-                <p>잔여 한도 1,200만원</p>
+            <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
+              <h3 className="mb-4 text-xl font-bold text-[#1F2937]">
+                대출 현황
+              </h3>
+              <div className="mb-4 text-3xl font-bold text-[#4A67E8]">
+                연 3.2% 적용중
+              </div>
+              <div className="mb-6 space-y-2 text-[#475569]">
+                <p>서민생활 안정 대출</p>
+                <p>대출 한도 1,200만원</p>
                 <p>다음 납부일 2026.04.25</p>
               </div>
-              <button className="block w-full bg-white text-[#1F2937] py-3 rounded-xl font-bold text-center hover:bg-white/90 transition-all shadow-sm">
+              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
                 상세 보기
               </button>
             </section>
 
-            <section className="bg-white/60 backdrop-blur-lg rounded-3xl p-6 shadow-2xl border-2 border-white/40">
-              <h3 className="text-xl font-bold text-[#1F2937] mb-4">자격증 인증 상태</h3>
-              <div className="text-3xl font-bold text-[#4A67E8] mb-4">서류 업로드 대기</div>
-              <div className="space-y-2 mb-6 text-[#475569]">
-                <p>자격증 이미지를 제출하면 OCR 인증이 시작됩니다.</p>
-                <p>인증 완료 시 우대 금리 적용 여부를 확인할 수 있습니다.</p>
+            <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
+              <h3 className="mb-4 text-xl font-bold text-[#1F2937]">
+                자격증 인증 상태
+              </h3>
+              <div className="mb-4 text-3xl font-bold text-[#4A67E8]">
+                서류 업로드 대기
               </div>
-              <button className="block w-full bg-white text-[#1F2937] py-3 rounded-xl font-bold text-center hover:bg-white/90 transition-all shadow-sm">
+              <div className="mb-6 space-y-2 text-[#475569]">
+                <p>자격증 이미지를 제출하면 OCR 인증이 시작됩니다.</p>
+                <p>인증 완료 후 우대 금리 적용 여부를 확인할 수 있습니다.</p>
+              </div>
+              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
                 인증하러 가기
               </button>
             </section>
           </div>
         </div>
 
-        <section className="bg-white/60 backdrop-blur-lg rounded-3xl p-8 shadow-2xl border-2 border-white/40 mb-8">
-          <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_0.8fr] gap-6">
+        <section className="mb-8 rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.8fr]">
             <div>
               <div className="mb-6">
-                <p className="text-sm text-[#64748B] mb-2">자격증 인증</p>
-                <h2 className="text-2xl font-bold text-[#1F2937]">이미지 업로드로 우대 금리 혜택을 확인하세요</h2>
-                <p className="text-[#64748B] mt-3 leading-7">
-                  자격증 이미지를 업로드하면 OCR로 텍스트를 추출하고, 자격증명과 발급기관을 확인해
-                  우대 금리 적용 가능 여부를 안내합니다.
+                <p className="mb-2 text-sm text-[#64748B]">자격증 인증</p>
+                <h2 className="text-2xl font-bold text-[#1F2937]">
+                  이미지 업로드로 우대 금리 혜택을 확인하세요
+                </h2>
+                <p className="mt-3 leading-7 text-[#64748B]">
+                  자격증 이미지 또는 PDF를 업로드하면 OCR로 텍스트를 추출하고,
+                  자격증명과 발급기관을 확인해 인증 결과를 안내합니다.
                 </p>
               </div>
 
@@ -206,67 +288,71 @@ export default function MyPage() {
                   className="hidden"
                   onChange={handleFileSelect}
                 />
-                <div className="w-14 h-14 rounded-full bg-[#E0E8FF] flex items-center justify-center mb-4">
-                  <Upload className="w-7 h-7 text-[#4A67E8]" />
+                <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[#E0E8FF]">
+                  <Upload className="h-7 w-7 text-[#4A67E8]" />
                 </div>
-                <h3 className="text-xl font-bold text-[#1F2937] mb-2">자격증 파일 업로드</h3>
-                <p className="text-[#64748B] mb-6">
-                  JPG, PNG, PDF 형식의 자격증 이미지를 업로드해주세요.
+                <h3 className="mb-2 text-xl font-bold text-[#1F2937]">
+                  자격증 파일 업로드
+                </h3>
+                <p className="mb-6 text-[#64748B]">
+                  JPG, PNG, PDF 형식의 자격증 파일을 업로드해 주세요.
                 </p>
 
-                <div className="mb-6 rounded-2xl bg-white px-5 py-4 shadow-sm border border-[#E2E8F0]">
+                <div className="mb-6 rounded-2xl border border-[#E2E8F0] bg-white px-5 py-4 shadow-sm">
                   <p className="text-sm font-medium text-[#334155]">
                     {selectedFile ? selectedFile.name : "선택된 파일이 없습니다."}
                   </p>
-                  <p className="text-sm text-[#64748B] mt-1">
+                  <p className="mt-1 text-sm text-[#64748B]">
                     {selectedFile
                       ? `${Math.ceil(selectedFile.size / 1024)}KB`
                       : "파일을 선택하면 여기에 파일명이 표시됩니다."}
                   </p>
                 </div>
 
-                <div className="flex flex-col sm:flex-row gap-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <button
                     type="button"
-                    onClick={handleFileSelect ? handleUploadClick : undefined}
-                    className="sm:flex-1 bg-[#B7C9FF] text-[#1F2937] py-4 rounded-xl font-bold hover:bg-[#a7bcff] transition-all shadow-md"
+                    onClick={handleUploadClick}
+                    className="sm:flex-1 rounded-xl bg-[#B7C9FF] py-4 font-bold text-[#1F2937] shadow-md transition-all hover:bg-[#a7bcff]"
                   >
                     파일 선택
                   </button>
                   <button
                     type="button"
-                    onClick={handleMockUpload}
+                    onClick={handleUpload}
                     disabled={!selectedFile || uploadStatus === "uploading"}
-                    className="sm:flex-1 bg-white text-[#1F2937] py-4 rounded-xl font-bold hover:bg-white/90 transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="sm:flex-1 rounded-xl bg-white py-4 font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    {uploadStatus === "uploading" ? "업로드 중..." : "업로드 시작"}
+                    {uploadStatus === "uploading"
+                      ? "업로드 중..."
+                      : "업로드 시작"}
                   </button>
                 </div>
               </div>
             </div>
 
             <div className="space-y-4">
-              <div className="bg-white/80 rounded-2xl p-5 shadow-lg border border-white/70">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className="w-10 h-10 rounded-full bg-[#E0E8FF] flex items-center justify-center">
-                    <FileSearch className="w-5 h-5 text-[#4A67E8]" />
+              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#E0E8FF]">
+                    <FileSearch className="h-5 w-5 text-[#4A67E8]" />
                   </div>
                   <div>
                     <p className="text-sm text-[#64748B]">OCR 진행 상태</p>
-                    <h3 className="text-lg font-bold text-[#1F2937]">업로드 전</h3>
+                    <h3 className="text-lg font-bold text-[#1F2937]">
+                      업로드 현황
+                    </h3>
                   </div>
                 </div>
-                <p className="text-sm text-[#64748B]">
-                  {statusText[uploadStatus]}
-                </p>
+                <p className="text-sm text-[#64748B]">{statusText[uploadStatus]}</p>
               </div>
 
-              <div className="bg-white/80 rounded-2xl p-5 shadow-lg border border-white/70">
-                <p className="text-sm text-[#64748B] mb-3">인증 절차</p>
+              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
+                <p className="mb-3 text-sm text-[#64748B]">인증 단계</p>
                 <div className="space-y-3">
                   {ocrSteps.map((step, index) => (
                     <div key={step} className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-[#E0E8FF] text-[#4A67E8] flex items-center justify-center font-semibold text-sm">
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[#E0E8FF] text-sm font-semibold text-[#4A67E8]">
                         {index + 1}
                       </div>
                       <p className="text-sm font-medium text-[#334155]">{step}</p>
@@ -275,52 +361,94 @@ export default function MyPage() {
                 </div>
               </div>
 
-              <div className="bg-white/80 rounded-2xl p-5 shadow-lg border border-white/70">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className="w-10 h-10 rounded-full bg-[#E7F8EE] flex items-center justify-center">
-                    <BadgeCheck className="w-5 h-5 text-[#16A34A]" />
+              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#E7F8EE]">
+                    <BadgeCheck className="h-5 w-5 text-[#16A34A]" />
                   </div>
                   <div>
                     <p className="text-sm text-[#64748B]">예상 혜택</p>
-                    <h3 className="text-lg font-bold text-[#1F2937]">우대 금리 적용 검토</h3>
+                    <h3 className="text-lg font-bold text-[#1F2937]">
+                      우대 금리 적용 검토
+                    </h3>
                   </div>
                 </div>
                 <p className="text-sm text-[#64748B]">
-                  인증 성공 시 등록된 자격증 기준으로 대출 금리 인하 가능 여부를 안내합니다.
+                  인증이 완료되면 자격증 기준으로 우대 금리 적용 가능 여부를
+                  확인합니다.
                 </p>
               </div>
 
+              {uploadStatus === "failed" && uploadError && (
+                <div className="rounded-2xl border border-[#FECACA] bg-[#FEF2F2] p-5 shadow-lg">
+                  <p className="mb-2 text-sm text-[#B91C1C]">업로드 오류</p>
+                  <p className="text-sm text-[#7F1D1D]">{uploadError}</p>
+                </div>
+              )}
+
               {uploadStatus === "completed" && (
-                <div className="bg-white/80 rounded-2xl p-5 shadow-lg border border-white/70">
-                  <p className="text-sm text-[#64748B] mb-2">업로드 결과</p>
-                  <h3 className="text-lg font-bold text-[#1F2937] mb-2">OCR 연동 준비 완료</h3>
-                  <p className="text-sm text-[#64748B]">
-                    현재는 프론트에서 파일 선택과 업로드 상태까지만 연결된 상태입니다. 다음 단계에서
-                    백엔드 API와 OCR 결과 텍스트를 붙이면 됩니다.
-                  </p>
+                <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
+                  <p className="mb-2 text-sm text-[#64748B]">업로드 결과</p>
+                  <h3 className="mb-2 text-lg font-bold text-[#1F2937]">
+                    OCR 연동 완료
+                  </h3>
+                  <div className="space-y-3 text-sm text-[#475569]">
+                    <p>
+                      인증 상태:{" "}
+                      <span className="font-semibold text-[#1F2937]">
+                        {ocrResult?.verificationStatus ?? "-"}
+                      </span>
+                    </p>
+                    <p>
+                      추출 라인 수:{" "}
+                      <span className="font-semibold text-[#1F2937]">
+                        {ocrResult?.lineCount ?? 0}
+                      </span>
+                    </p>
+                    <p className="font-medium text-[#334155]">
+                      OCR 추출 결과
+                    </p>
+                    <div className="max-h-48 overflow-y-auto rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] p-4 text-[#334155]">
+                      {ocrResult?.lines?.length ? (
+                        <div className="space-y-2">
+                          {ocrResult.lines.map((line, index) => (
+                            <p key={`${line}-${index}`}>{line}</p>
+                          ))}
+                        </div>
+                      ) : (
+                        <p>추출된 텍스트가 없습니다.</p>
+                      )}
+                    </div>
+                  </div>
                 </div>
               )}
             </div>
           </div>
         </section>
 
-        <section className="bg-white/60 backdrop-blur-lg rounded-3xl p-8 shadow-2xl border-2 border-white/40">
+        <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
           <div className="mb-6">
-            <p className="text-sm text-[#64748B] mb-2">빠른 메뉴</p>
-            <h2 className="text-2xl font-bold text-[#1F2937]">자주 찾는 서비스</h2>
+            <p className="mb-2 text-sm text-[#64748B]">빠른 메뉴</p>
+            <h2 className="text-2xl font-bold text-[#1F2937]">
+              자주 찾는 서비스
+            </h2>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             {quickMenus.map(({ title, description, icon: Icon }) => (
               <article
                 key={title}
-                className="p-6 bg-white/80 rounded-2xl shadow-lg border border-white/70 hover:shadow-xl transition-all"
+                className="rounded-2xl border border-white/70 bg-white/80 p-6 shadow-lg transition-all hover:shadow-xl"
               >
-                <div className="w-12 h-12 rounded-full bg-[#E0E8FF] flex items-center justify-center mb-4">
-                  <Icon className="w-6 h-6 text-[#4A67E8]" />
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[#E0E8FF]">
+                  <Icon className="h-6 w-6 text-[#4A67E8]" />
                 </div>
-                <h3 className="text-xl font-bold mb-2 text-[#1F2937]">{title}</h3>
-                <p className="text-[#64748B] leading-6 text-sm">{description}</p>
+                <h3 className="mb-2 text-xl font-bold text-[#1F2937]">
+                  {title}
+                </h3>
+                <p className="text-sm leading-6 text-[#64748B]">
+                  {description}
+                </p>
               </article>
             ))}
           </div>

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -7,6 +7,7 @@ import {
   Upload,
   User,
 } from "lucide-react";
+import { API_BASE } from "../../lib/api";
 
 const quickMenus = [
   {
@@ -51,10 +52,6 @@ type CertificateSubmissionResponse = {
   submittedAt: string;
 };
 
-const API_BASE_URL = "http://localhost:9999";
-const DEFAULT_MEMBER_ID = "1";
-const DEFAULT_LOAN_ID = "1";
-const DEFAULT_CERTIFICATE_ID = "1";
 const NO_TEXT_DETECTED_MESSAGE =
   "자격증 내용을 확인할 수 없습니다. 자격증 전체가 잘 보이는 이미지 또는 PDF를 업로드해 주세요.";
 
@@ -65,6 +62,9 @@ export default function MyPage() {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [ocrResult, setOcrResult] =
     useState<CertificateSubmissionResponse | null>(null);
+  const [memberId, setMemberId] = useState("");
+  const [loanId, setLoanId] = useState("");
+  const [certificateId, setCertificateId] = useState("");
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0] ?? null;
@@ -92,23 +92,27 @@ export default function MyPage() {
       return;
     }
 
+    if (!memberId || !loanId || !certificateId) {
+      setUploadStatus("failed");
+      setUploadError("회원 ID, 대출 ID, 자격증 ID를 모두 입력해 주세요.");
+      return;
+    }
+
     const formData = new FormData();
-    formData.append("memberId", DEFAULT_MEMBER_ID);
-    formData.append("loanId", DEFAULT_LOAN_ID);
-    formData.append("certificateId", DEFAULT_CERTIFICATE_ID);
+    formData.append("memberId", memberId);
+    formData.append("loanId", loanId);
+    formData.append("certificateId", certificateId);
     formData.append("file", selectedFile);
 
     setUploadStatus("uploading");
     setUploadError(null);
 
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/certificates/submissions`,
-        {
-          method: "POST",
-          body: formData,
-        },
-      );
+      const response = await fetch(`${API_BASE}/api/certificates/submissions`, {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
 
       if (!response.ok) {
         const errorBody = (await response.json().catch(() => null)) as
@@ -278,6 +282,33 @@ export default function MyPage() {
                   자격증 이미지 또는 PDF를 업로드하면 OCR로 텍스트를 추출하고,
                   자격증명과 발급기관을 확인해 인증 결과를 안내합니다.
                 </p>
+              </div>
+
+              <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+                <input
+                  type="number"
+                  min="1"
+                  value={memberId}
+                  onChange={(event) => setMemberId(event.target.value)}
+                  placeholder="회원 ID"
+                  className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-3 text-sm text-[#1F2937] shadow-sm focus:border-[#94A3B8] focus:outline-none"
+                />
+                <input
+                  type="number"
+                  min="1"
+                  value={loanId}
+                  onChange={(event) => setLoanId(event.target.value)}
+                  placeholder="대출 ID"
+                  className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-3 text-sm text-[#1F2937] shadow-sm focus:border-[#94A3B8] focus:outline-none"
+                />
+                <input
+                  type="number"
+                  min="1"
+                  value={certificateId}
+                  onChange={(event) => setCertificateId(event.target.value)}
+                  placeholder="자격증 ID"
+                  className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-3 text-sm text-[#1F2937] shadow-sm focus:border-[#94A3B8] focus:outline-none"
+                />
               </div>
 
               <div className="rounded-3xl border-2 border-dashed border-[#B7C9FF] bg-[#F8FAFF] p-8">


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #18 

---

### 📝 작업 내용

- 마이페이지 자격증 업로드 영역에 실제 백엔드 OCR API 호출을 연결했습니다.
- `multipart/form-data`로 `memberId`, `loanId`, `certificateId`, `file`를 전송하도록 구현했습니다.
- 업로드 상태를 `idle`, `selected`, `uploading`, `completed`, `failed`로 나누어 UI에 반영했습니다.
- OCR 응답 결과를 기반으로 인증 상태, 추출 라인 수, OCR 텍스트 목록을 화면에 표시하도록 구현했습니다.
- OCR 실패 시 에러 메시지를 사용자 친화적인 문구로 가공해 표시하도록 수정했습니다.
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실제 서버 연동 파일 업로드로 전환되었습니다.
  * OCR 처리 결과(검증 상태, 라인 수, 추출된 텍스트 목록)를 결과 패널에 표시합니다.
  * UI 문구를 정비하여 “이미지 업로드”가 “파일 업로드”로 변경되었습니다.

* **버그 수정**
  * 필수 식별자 없이 업로드 시 검증 오류 처리 및 명확한 실패 메시지를 표시합니다.
  * 서버 응답 오류에 대한 사용자 친화적 오류 문구를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->