### PR TITLE
Feat: 자기계발 대출 상품 및 OCR 제출 UI 연동

### DIFF
--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -1,4 +1,4 @@
-﻿export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:9999";
+﻿﻿export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:9999";
 
 let refreshPromise: Promise<boolean> | null = null;
 

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -1,4 +1,5 @@
 import { BadgeCheck, CreditCard, FileText, User } from "lucide-react";
+import { Link } from "react-router";
 
 const quickMenus = [
   {
@@ -92,12 +93,18 @@ export default function MyPage() {
             </div>
 
             <div className="flex gap-4">
-              <button className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
+              <Link
+                to="/mypage"
+                className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
+              >
                 내 정보 보기
-              </button>
-              <button className="flex-1 rounded-xl bg-blue-100 py-4 font-bold text-slate-900 shadow-md transition-all hover:bg-blue-200">
+              </Link>
+              <Link
+                to="/loan/management"
+                className="flex-1 rounded-xl bg-blue-100 py-4 text-center font-bold text-slate-900 shadow-md transition-all hover:bg-blue-200"
+              >
                 대출 관리로 이동
-              </button>
+              </Link>
             </div>
           </section>
 
@@ -110,9 +117,12 @@ export default function MyPage() {
                 <p>다음 납입일 2026.04.25</p>
                 <p>내 대출 관리에서 상세 확인 가능</p>
               </div>
-              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
+              <Link
+                to="/loan/management"
+                className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
+              >
                 상세 보기
-              </button>
+              </Link>
             </section>
 
             <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
@@ -121,9 +131,12 @@ export default function MyPage() {
                 <p>제출 서류와 인증 결과는 대출 관리에서 확인할 수 있습니다.</p>
                 <p>상품 신청 상태에 따라 추가 안내가 표시됩니다.</p>
               </div>
-              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
+              <Link
+                to="/loan/management"
+                className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
+              >
                 확인하러 가기
-              </button>
+              </Link>
             </section>
           </div>
         </div>

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -1,18 +1,9 @@
-import { useRef, useState } from "react";
-import {
-  BadgeCheck,
-  CreditCard,
-  FileSearch,
-  FileText,
-  Upload,
-  User,
-} from "lucide-react";
-import { API_BASE } from "../../lib/api";
+import { BadgeCheck, CreditCard, FileText, User } from "lucide-react";
 
 const quickMenus = [
   {
-    title: "내 정보 관리",
-    description: "회원 정보와 이용 현황을 한 번에 확인합니다.",
+    title: "회원정보 관리",
+    description: "기본 회원 정보와 최근 이용 상태를 확인합니다.",
     icon: User,
   },
   {
@@ -22,218 +13,17 @@ const quickMenus = [
   },
   {
     title: "카드 이용내역",
-    description: "최근 결제 내역과 상세 사용 정보를 조회합니다.",
+    description: "최근 결제 내역과 카드 사용 흐름을 조회합니다.",
     icon: CreditCard,
   },
   {
     title: "인증 결과 조회",
-    description: "자격증 인증 결과와 제출 상태를 확인합니다.",
+    description: "서류 제출 결과와 인증 진행 상태를 확인합니다.",
     icon: BadgeCheck,
   },
 ];
 
-const ocrSteps = [
-  "자격증 종류 선택",
-  "파일 업로드",
-  "OCR 텍스트 추출",
-  "자격증명과 발급기관 검증",
-];
-
-const certificateGroups = [
-  {
-    label: "사무/기초",
-    options: [
-      { id: "1", label: "컴퓨터활용능력 1급" },
-      { id: "2", label: "컴퓨터활용능력 2급" },
-      { id: "3", label: "워드프로세서" },
-      { id: "4", label: "한국사능력검정시험" },
-    ],
-  },
-  {
-    label: "IT/데이터",
-    options: [
-      { id: "5", label: "정보처리기사" },
-      { id: "6", label: "정보처리산업기사" },
-      { id: "7", label: "ADsP" },
-      { id: "8", label: "SQLD" },
-      { id: "9", label: "빅데이터분석기사" },
-    ],
-  },
-  {
-    label: "회계/금융",
-    options: [
-      { id: "10", label: "전산회계 1급" },
-      { id: "11", label: "전산세무 2급" },
-      { id: "12", label: "투자자산운용사" },
-      { id: "13", label: "AFPK" },
-      { id: "14", label: "신용분석사" },
-    ],
-  },
-  {
-    label: "어학",
-    options: [
-      { id: "18", label: "JLPT" },
-      { id: "19", label: "HSK" },
-    ],
-  },
-  {
-    label: "전문 자격",
-    options: [
-      { id: "20", label: "공인중개사" },
-      { id: "21", label: "감정평가사" },
-      { id: "22", label: "세무사" },
-      { id: "23", label: "공인회계사" },
-      { id: "24", label: "변호사" },
-    ],
-  },
-  {
-    label: "기사",
-    options: [
-      { id: "25", label: "전기기사" },
-      { id: "26", label: "산업안전기사" },
-      { id: "27", label: "건축기사" },
-      { id: "28", label: "토목기사" },
-      { id: "29", label: "기계기사" },
-    ],
-  },
-];
-
-type UploadStatus = "idle" | "selected" | "uploading" | "completed" | "failed";
-
-type CertificateSubmissionResponse = {
-  submissionId: number;
-  filename: string;
-  contentType: string;
-  extractedText: string;
-  lines: string[];
-  lineCount: number;
-  verificationStatus: string;
-  failureReason: string | null;
-  submittedAt: string;
-};
-
-const NO_TEXT_DETECTED_MESSAGE =
-  "자격증 내용을 확인할 수 없습니다. 자격증 전체가 잘 보이는 이미지 또는 PDF를 업로드해 주세요.";
-
-const failureReasonMessages: Record<string, string> = {
-  CERTIFICATE_NAME_MISMATCH:
-    "선택한 자격증 종류와 업로드한 문서가 일치하지 않습니다.",
-  ISSUER_NAME_MISMATCH:
-    "발급기관 정보를 확인할 수 없습니다. 문서 원본을 다시 확인해 주세요.",
-  NAME_MISMATCH: "회원 정보의 이름과 문서의 이름이 일치하지 않습니다.",
-  PASS_KEYWORD_NOT_FOUND:
-    "합격 또는 취득을 확인할 수 있는 문구를 찾지 못했습니다.",
-  INVALID_DOCUMENT_TYPE: "자격증 인증용 문서로 확인되지 않았습니다.",
-  OCR_TEXT_NOT_DETECTED: NO_TEXT_DETECTED_MESSAGE,
-};
-
 export default function MyPage() {
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [ocrResult, setOcrResult] =
-    useState<CertificateSubmissionResponse | null>(null);
-  const [memberId, setMemberId] = useState("");
-  const [loanId, setLoanId] = useState("");
-  const [certificateId, setCertificateId] = useState("");
-
-  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0] ?? null;
-
-    if (!file) {
-      setSelectedFile(null);
-      setUploadStatus("idle");
-      setUploadError(null);
-      setOcrResult(null);
-      return;
-    }
-
-    setSelectedFile(file);
-    setUploadStatus("selected");
-    setUploadError(null);
-    setOcrResult(null);
-  };
-
-  const handleUploadClick = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleUpload = async () => {
-    if (!selectedFile) {
-      return;
-    }
-
-    if (!memberId || !loanId || !certificateId) {
-      setUploadStatus("failed");
-      setUploadError("회원 ID, 대출 ID, 자격증 종류를 모두 입력해 주세요.");
-      return;
-    }
-
-    const formData = new FormData();
-    formData.append("memberId", memberId);
-    formData.append("loanId", loanId);
-    formData.append("certificateId", certificateId);
-    formData.append("file", selectedFile);
-
-    setUploadStatus("uploading");
-    setUploadError(null);
-
-    try {
-      const response = await fetch(`${API_BASE}/api/certificates/submissions`, {
-        method: "POST",
-        credentials: "include",
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const errorBody = (await response.json().catch(() => null)) as
-          | { message?: string }
-          | null;
-        const message = errorBody?.message ?? "자격증 업로드에 실패했습니다.";
-        throw new Error(
-          message.includes("No text detected from image")
-            ? NO_TEXT_DETECTED_MESSAGE
-            : message,
-        );
-      }
-
-      const result =
-        (await response.json()) as CertificateSubmissionResponse;
-      setOcrResult(result);
-
-      if (
-        result.verificationStatus === "VERIFICATION_FAILED" &&
-        result.failureReason
-      ) {
-        setUploadStatus("failed");
-        setUploadError(
-          failureReasonMessages[result.failureReason] ??
-            "자격증 인증에 실패했습니다. 업로드한 문서를 다시 확인해 주세요.",
-        );
-        return;
-      }
-
-      setUploadStatus("completed");
-    } catch (error) {
-      setUploadStatus("failed");
-      setUploadError(
-        error instanceof Error
-          ? error.message
-          : "알 수 없는 오류가 발생했습니다.",
-      );
-      setOcrResult(null);
-    }
-  };
-
-  const statusText: Record<UploadStatus, string> = {
-    idle: "자격증 종류를 선택하고 파일을 업로드해 주세요.",
-    selected: `선택된 파일: ${selectedFile?.name ?? ""}`,
-    uploading: "OCR 요청을 전송하고 있습니다.",
-    completed: "OCR 업로드가 완료되었습니다. 인증 결과를 확인해 주세요.",
-    failed: uploadError ?? "업로드 중 오류가 발생했습니다.",
-  };
-
   return (
     <div className="min-h-screen">
       <div className="mx-auto max-w-7xl px-4 py-12">
@@ -242,12 +32,10 @@ export default function MyPage() {
             <div className="rounded-full border-2 border-white/30 bg-white/20 p-3 shadow-lg backdrop-blur-md">
               <User className="h-8 w-8 text-white" />
             </div>
-            <h1 className="text-4xl font-bold text-[#1F2937] drop-shadow-lg">
-              마이페이지
-            </h1>
+            <h1 className="text-4xl font-bold text-slate-900 drop-shadow-lg">마이페이지</h1>
           </div>
-          <p className="ml-16 text-xl text-[#475569] drop-shadow-lg">
-            자격증 인증과 대출 이용 현황을 한 화면에서 확인할 수 있습니다.
+          <p className="ml-16 text-xl text-slate-600 drop-shadow-lg">
+            내 정보와 금융 이용 현황을 한 곳에서 확인할 수 있습니다.
           </p>
         </div>
 
@@ -256,335 +44,94 @@ export default function MyPage() {
             <div className="mb-8 flex items-start justify-between gap-6">
               <div className="flex-1">
                 <div className="mb-4 flex items-center gap-3">
-                  <h2 className="text-2xl font-bold text-[#1F2937]">
-                    내 금융 현황
-                  </h2>
-                  <span className="rounded-full bg-[#B7C9FF] px-4 py-1 text-sm font-semibold text-[#1F2937] shadow-md">
-                    자격증 인증 가능
+                  <h2 className="text-2xl font-bold text-slate-900">내 금융 현황</h2>
+                  <span className="rounded-full bg-blue-100 px-4 py-1 text-sm font-semibold text-slate-900 shadow-md">
+                    요약 보기
                   </span>
                 </div>
 
                 <div className="mb-6">
-                  <div className="mb-2 text-5xl font-bold text-[#4A67E8]">
-                    NUDGE CARE
-                  </div>
-                  <p className="text-base text-[#475569]">
-                    자격증 인증 결과를 바탕으로 자기개발 대출 이용 여부를
-                    확인할 수 있습니다.
+                  <div className="mb-2 text-5xl font-bold text-blue-600">NUDGE CARE</div>
+                  <p className="text-base text-slate-600">
+                    계좌, 대출, 카드 이용 상태를 빠르게 확인하고 필요한 메뉴로 바로 이동할 수 있습니다.
                   </p>
                 </div>
 
                 <div className="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-3">
                   <div>
-                    <p className="mb-1 text-sm text-[#64748B]">보유 계좌</p>
-                    <p className="text-2xl font-bold text-[#1F2937]">2개</p>
+                    <p className="mb-1 text-sm text-slate-500">보유 계좌</p>
+                    <p className="text-2xl font-bold text-slate-900">2개</p>
                   </div>
                   <div>
-                    <p className="mb-1 text-sm text-[#64748B]">이용 중 대출</p>
-                    <p className="text-2xl font-bold text-[#1F2937]">1건</p>
+                    <p className="mb-1 text-sm text-slate-500">이용 중 대출</p>
+                    <p className="text-2xl font-bold text-slate-900">1건</p>
                   </div>
                   <div>
-                    <p className="mb-1 text-sm text-[#64748B]">인증 상태</p>
-                    <p className="text-2xl font-bold text-[#1F2937]">심사 중</p>
+                    <p className="mb-1 text-sm text-slate-500">최근 확인 항목</p>
+                    <p className="text-2xl font-bold text-slate-900">대출 관리</p>
                   </div>
                 </div>
 
                 <div className="mb-6 flex flex-wrap gap-2">
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
                     계좌 조회
                   </span>
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
                     대출 현황
                   </span>
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-[#334155] shadow-sm">
-                    자격증 인증
+                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
+                    카드 내역
                   </span>
                 </div>
               </div>
 
               <div className="relative hidden h-64 w-64 flex-shrink-0 items-center justify-center md:flex">
-                <div className="absolute h-32 w-48 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 opacity-80 shadow-2xl blur-sm"></div>
-                <div className="absolute h-28 w-40 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 shadow-xl"></div>
+                <div className="absolute h-32 w-48 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 opacity-80 shadow-2xl blur-sm" />
+                <div className="absolute h-28 w-40 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 shadow-xl" />
               </div>
             </div>
 
             <div className="flex gap-4">
-              <button className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
+              <button className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
                 내 정보 보기
               </button>
-              <button className="flex-1 rounded-xl bg-[#B7C9FF] py-4 font-bold text-[#1F2937] shadow-md transition-all hover:bg-[#a7bcff]">
-                자격증 인증 시작
+              <button className="flex-1 rounded-xl bg-blue-100 py-4 font-bold text-slate-900 shadow-md transition-all hover:bg-blue-200">
+                대출 관리로 이동
               </button>
             </div>
           </section>
 
           <div className="space-y-6">
             <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
-              <h3 className="mb-4 text-xl font-bold text-[#1F2937]">
-                대출 현황
-              </h3>
-              <div className="mb-4 text-3xl font-bold text-[#4A67E8]">
-                심사 진행 중
+              <h3 className="mb-4 text-xl font-bold text-slate-900">대출 현황</h3>
+              <div className="mb-4 text-3xl font-bold text-blue-600">상환 진행 중</div>
+              <div className="mb-6 space-y-2 text-slate-600">
+                <p>진행 중인 대출 1건</p>
+                <p>다음 납입일 2026.04.25</p>
+                <p>내 대출 관리에서 상세 확인 가능</p>
               </div>
-              <div className="mb-6 space-y-2 text-[#475569]">
-                <p>자기개발 대출 신청 1건</p>
-                <p>예상 한도 1,200만원</p>
-                <p>다음 확인일 2026.04.25</p>
-              </div>
-              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
+              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
                 상세 보기
               </button>
             </section>
 
             <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
-              <h3 className="mb-4 text-xl font-bold text-[#1F2937]">
-                자격증 인증 상태
-              </h3>
-              <div className="mb-4 text-3xl font-bold text-[#4A67E8]">
-                서류 업로드 대기
+              <h3 className="mb-4 text-xl font-bold text-slate-900">알림</h3>
+              <div className="mb-6 space-y-2 text-slate-600">
+                <p>제출 서류와 인증 결과는 대출 관리에서 확인할 수 있습니다.</p>
+                <p>상품 신청 상태에 따라 추가 안내가 표시됩니다.</p>
               </div>
-              <div className="mb-6 space-y-2 text-[#475569]">
-                <p>자격증 파일을 올리면 OCR 인증이 시작됩니다.</p>
-                <p>인증 완료 후 결과를 마이페이지에서 확인할 수 있습니다.</p>
-              </div>
-              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90">
-                인증하러 가기
+              <button className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90">
+                확인하러 가기
               </button>
             </section>
           </div>
         </div>
 
-        <section className="mb-8 rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-            <div>
-              <div className="mb-6">
-                <p className="mb-2 text-sm text-[#64748B]">자격증 인증</p>
-                <h2 className="text-2xl font-bold text-[#1F2937]">
-                  자격증 종류를 선택하고 파일을 업로드해 주세요
-                </h2>
-                <p className="mt-3 leading-7 text-[#64748B]">
-                  자격증 종류를 먼저 선택한 뒤 이미지 또는 PDF를 업로드하면 OCR
-                  추출과 자격증 검증을 진행합니다.
-                </p>
-              </div>
-
-              <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
-                <input
-                  type="number"
-                  min="1"
-                  value={memberId}
-                  onChange={(event) => setMemberId(event.target.value)}
-                  placeholder="회원 ID"
-                  className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-3 text-sm text-[#1F2937] shadow-sm focus:border-[#94A3B8] focus:outline-none"
-                />
-                <input
-                  type="number"
-                  min="1"
-                  value={loanId}
-                  onChange={(event) => setLoanId(event.target.value)}
-                  placeholder="대출 ID"
-                  className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-3 text-sm text-[#1F2937] shadow-sm focus:border-[#94A3B8] focus:outline-none"
-                />
-                <div className="rounded-xl border border-[#D7DEEA] bg-white px-4 py-2 shadow-sm">
-                  <p className="mb-1 text-xs font-medium text-[#64748B]">
-                    자격증 종류
-                  </p>
-                  <select
-                    value={certificateId}
-                    onChange={(event) => setCertificateId(event.target.value)}
-                    className="w-full bg-transparent py-1 text-sm text-[#1F2937] focus:outline-none"
-                  >
-                    <option value="">자격증 종류 선택</option>
-                    {certificateGroups.map((group) => (
-                      <optgroup key={group.label} label={group.label}>
-                        {group.options.map((certificate) => (
-                          <option key={certificate.id} value={certificate.id}>
-                            {certificate.label}
-                          </option>
-                        ))}
-                      </optgroup>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              <div className="mb-4 rounded-2xl border border-[#E2E8F0] bg-white/80 p-4 shadow-sm">
-                <div className="mb-3 flex items-center justify-between">
-                  <p className="font-medium text-[#334155]">
-                    지원 자격증 안내
-                  </p>
-                  <span className="rounded-full bg-[#E0E8FF] px-3 py-1 text-xs font-semibold text-[#3653d6]">
-                    총 26종
-                  </span>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs text-[#475569]">
-                  {certificateGroups.map((group) => (
-                    <span
-                      key={group.label}
-                      className="rounded-full border border-[#D7DEEA] bg-[#F8FAFF] px-3 py-1"
-                    >
-                      {group.label}
-                    </span>
-                  ))}
-                </div>
-                <p className="mt-3 text-xs text-[#64748B]">
-                  점수형 어학 시험은 제외되며, 합격 또는 급수형 시험만 선택할 수
-                  있습니다.
-                </p>
-              </div>
-
-              <div className="rounded-3xl border-2 border-dashed border-[#B7C9FF] bg-[#F8FAFF] p-8">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".jpg,.jpeg,.png,.pdf"
-                  className="hidden"
-                  onChange={handleFileSelect}
-                />
-                <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[#E0E8FF]">
-                  <Upload className="h-7 w-7 text-[#4A67E8]" />
-                </div>
-                <h3 className="mb-2 text-xl font-bold text-[#1F2937]">
-                  자격증 파일 업로드
-                </h3>
-                <p className="mb-6 text-[#64748B]">
-                  JPG, PNG, PDF 형식의 자격증 파일을 업로드해 주세요.
-                </p>
-
-                <div className="mb-6 rounded-2xl border border-[#E2E8F0] bg-white px-5 py-4 shadow-sm">
-                  <p className="text-sm font-medium text-[#334155]">
-                    {selectedFile ? selectedFile.name : "선택된 파일이 없습니다."}
-                  </p>
-                  <p className="mt-1 text-sm text-[#64748B]">
-                    {selectedFile
-                      ? `${Math.ceil(selectedFile.size / 1024)}KB`
-                      : "파일을 선택하면 이 영역에 파일명이 표시됩니다."}
-                  </p>
-                </div>
-
-                <div className="flex flex-col gap-4 sm:flex-row">
-                  <button
-                    type="button"
-                    onClick={handleUploadClick}
-                    className="sm:flex-1 rounded-xl bg-[#B7C9FF] py-4 font-bold text-[#1F2937] shadow-md transition-all hover:bg-[#a7bcff]"
-                  >
-                    파일 선택
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleUpload}
-                    disabled={!selectedFile || uploadStatus === "uploading"}
-                    className="sm:flex-1 rounded-xl bg-white py-4 font-bold text-[#1F2937] shadow-sm transition-all hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {uploadStatus === "uploading"
-                      ? "업로드 중..."
-                      : "업로드 시작"}
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-4">
-              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#E0E8FF]">
-                    <FileSearch className="h-5 w-5 text-[#4A67E8]" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-[#64748B]">OCR 진행 상태</p>
-                    <h3 className="text-lg font-bold text-[#1F2937]">
-                      업로드 현황
-                    </h3>
-                  </div>
-                </div>
-                <p className="text-sm text-[#64748B]">{statusText[uploadStatus]}</p>
-              </div>
-
-              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
-                <p className="mb-3 text-sm text-[#64748B]">인증 단계</p>
-                <div className="space-y-3">
-                  {ocrSteps.map((step, index) => (
-                    <div key={step} className="flex items-center gap-3">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[#E0E8FF] text-sm font-semibold text-[#4A67E8]">
-                        {index + 1}
-                      </div>
-                      <p className="text-sm font-medium text-[#334155]">{step}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#E7F8EE]">
-                    <BadgeCheck className="h-5 w-5 text-[#16A34A]" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-[#64748B]">인증 결과</p>
-                    <h3 className="text-lg font-bold text-[#1F2937]">
-                      자기개발 대출 검증
-                    </h3>
-                  </div>
-                </div>
-                <p className="text-sm text-[#64748B]">
-                  인증 완료 후 자격증 기준과 제출 문서를 비교한 결과를
-                  보여줍니다.
-                </p>
-              </div>
-
-              {uploadStatus === "failed" && uploadError && (
-                <div className="rounded-2xl border border-[#FECACA] bg-[#FEF2F2] p-5 shadow-lg">
-                  <p className="mb-2 text-sm text-[#B91C1C]">업로드 오류</p>
-                  <p className="text-sm text-[#7F1D1D]">{uploadError}</p>
-                </div>
-              )}
-
-              {uploadStatus === "completed" && (
-                <div className="rounded-2xl border border-white/70 bg-white/80 p-5 shadow-lg">
-                  <p className="mb-2 text-sm text-[#64748B]">업로드 결과</p>
-                  <h3 className="mb-2 text-lg font-bold text-[#1F2937]">
-                    OCR 연동 완료
-                  </h3>
-                  <div className="space-y-3 text-sm text-[#475569]">
-                    <p>
-                      인증 상태:{" "}
-                      <span className="font-semibold text-[#1F2937]">
-                        {ocrResult?.verificationStatus ?? "-"}
-                      </span>
-                    </p>
-                    <p>
-                      추출 라인 수:{" "}
-                      <span className="font-semibold text-[#1F2937]">
-                        {ocrResult?.lineCount ?? 0}
-                      </span>
-                    </p>
-                    <p className="font-medium text-[#334155]">
-                      OCR 추출 결과
-                    </p>
-                    <div className="max-h-48 overflow-y-auto rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] p-4 text-[#334155]">
-                      {ocrResult?.lines?.length ? (
-                        <div className="space-y-2">
-                          {ocrResult.lines.map((line, index) => (
-                            <p key={`${line}-${index}`}>{line}</p>
-                          ))}
-                        </div>
-                      ) : (
-                        <p>추출된 텍스트가 없습니다.</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
-
         <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
           <div className="mb-6">
-            <p className="mb-2 text-sm text-[#64748B]">빠른 메뉴</p>
-            <h2 className="text-2xl font-bold text-[#1F2937]">
-              자주 찾는 서비스
-            </h2>
+            <p className="mb-2 text-sm text-slate-500">빠른 메뉴</p>
+            <h2 className="text-2xl font-bold text-slate-900">자주 찾는 서비스</h2>
           </div>
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -593,15 +140,11 @@ export default function MyPage() {
                 key={title}
                 className="rounded-2xl border border-white/70 bg-white/80 p-6 shadow-lg transition-all hover:shadow-xl"
               >
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[#E0E8FF]">
-                  <Icon className="h-6 w-6 text-[#4A67E8]" />
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+                  <Icon className="h-6 w-6 text-blue-600" />
                 </div>
-                <h3 className="mb-2 text-xl font-bold text-[#1F2937]">
-                  {title}
-                </h3>
-                <p className="text-sm leading-6 text-[#64748B]">
-                  {description}
-                </p>
+                <h3 className="mb-2 text-xl font-bold text-slate-900">{title}</h3>
+                <p className="text-sm leading-6 text-slate-600">{description}</p>
               </article>
             ))}
           </div>

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -11,6 +11,20 @@ type LoanApplyConfig = {
   rate: string;
   defaultAmount: string;
   defaultPurpose: string;
+  amountRange: { min: number; max: number };
+  termOptions: string[];
+};
+
+const amountRanges: Record<string, { min: number; max: number }> = {
+  "consumption-loan": { min: 500000, max: 3000000 },
+  "youth-loan": { min: 500000, max: 5000000 },
+  "situate-loan": { min: 300000, max: 2000000 },
+};
+
+const termOptionsByProduct: Record<string, string[]> = {
+  "consumption-loan": ["6개월", "12개월", "18개월"],
+  "youth-loan": ["12개월", "18개월", "24개월"],
+  "situate-loan": ["1개월", "3개월", "6개월", "12개월"],
 };
 
 type LoanApplicationSummary = {
@@ -58,8 +72,13 @@ export default function LoanApply() {
   const { productId } = useParams<{ productId: string }>();
   const product = productId ? productConfigs[productId] : undefined;
   const [amount, setAmount] = useState(product?.defaultAmount ?? "");
-  const [loanTerm, setLoanTerm] = useState(productId === "youth-loan" ? "24개월" : "12개월");
+  const termOptions = productId ? termOptionsByProduct[productId] ?? ["12개월"] : ["12개월"];
+  const amountRange =
+    productId ? amountRanges[productId] ?? { min: 0, max: Number.MAX_SAFE_INTEGER } : { min: 0, max: Number.MAX_SAFE_INTEGER };
+  const [loanTerm, setLoanTerm] = useState(termOptions[0] ?? "12개월");
   const [purpose, setPurpose] = useState(product?.defaultPurpose ?? "");
+  const [monthlyIncome, setMonthlyIncome] = useState("");
+  const [salaryDate, setSalaryDate] = useState("");
   const [agreeTerms, setAgreeTerms] = useState(false);
   const [agreePrivacy, setAgreePrivacy] = useState(false);
   const [error, setError] = useState("");
@@ -94,14 +113,38 @@ export default function LoanApply() {
       return;
     }
 
+    const parsedAmount = Number(amount);
+    const parsedMonthlyIncome = Number(monthlyIncome);
+    const parsedSalaryDate = Number(salaryDate);
+
+    if (Number.isNaN(parsedAmount) || parsedAmount < amountRange.min || parsedAmount > amountRange.max) {
+      setError(`신청 금액은 ${amountRange.min.toLocaleString("ko-KR")}원~${amountRange.max.toLocaleString("ko-KR")}원 범위로 입력해 주세요.`);
+      return;
+    }
+
+    if (!termOptions.includes(loanTerm)) {
+      setError("상품 조건에 맞는 상환 기간을 선택해 주세요.");
+      return;
+    }
+
+    if (Number.isNaN(parsedMonthlyIncome) || parsedMonthlyIncome <= 0) {
+      setError("월 소득을 입력해 주세요.");
+      return;
+    }
+
+    if (Number.isNaN(parsedSalaryDate) || parsedSalaryDate < 1 || parsedSalaryDate > 31) {
+      setError("급여일은 1일부터 31일 사이로 입력해 주세요.");
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       await postJson<LoanApplicationSummary>("/api/loan-applications", {
         productKey: productId,
-        loanAmount: Number(amount),
+        loanAmount: parsedAmount,
         loanTerm,
-        monthlyIncome: 2500000,
-        salaryDate: 25,
+        monthlyIncome: parsedMonthlyIncome,
+        salaryDate: parsedSalaryDate,
         purpose,
       });
       window.dispatchEvent(new Event("loan-application-change"));
@@ -165,10 +208,33 @@ export default function LoanApply() {
                 onChange={(event) => setLoanTerm(event.target.value)}
                 className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
               >
-                <option>12개월</option>
-                <option>18개월</option>
-                <option>24개월</option>
+                {termOptions.map((termOption) => (
+                  <option key={termOption} value={termOption}>
+                    {termOption}
+                  </option>
+                ))}
               </select>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div>
+                <label className="mb-2 block text-sm font-medium text-slate-600">월 소득</label>
+                <input
+                  value={monthlyIncome}
+                  onChange={(event) => setMonthlyIncome(event.target.value)}
+                  className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+                  placeholder="월 소득을 입력해 주세요"
+                />
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-slate-600">급여일</label>
+                <input
+                  value={salaryDate}
+                  onChange={(event) => setSalaryDate(event.target.value)}
+                  className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+                  placeholder="매월 급여일을 입력해 주세요"
+                />
+              </div>
             </div>
 
             <div>
@@ -264,7 +330,7 @@ export default function LoanApply() {
               </div>
             </div>
             <p className="mt-4 text-sm leading-6 text-slate-700">
-              신청 정보는 브라우저 임시 저장 상태로 관리되고 있으며, 백엔드 연동 이후 실제 신청 데이터와 연결됩니다.
+              신청 정보는 백엔드에 바로 저장되며, 내 대출 관리에서 실제 신청 상태를 확인할 수 있습니다.
             </p>
           </div>
         </aside>

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -133,7 +133,7 @@ export default function LoanApply() {
   };
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-12">
+    <div className="mx-auto max-w-7xl px-4 py-12">
       <div className="mb-8">
         <Link
           to={`/loan/products/${productId}`}
@@ -143,7 +143,7 @@ export default function LoanApply() {
         </Link>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.85fr)]">
         <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
           <p className="text-sm font-semibold uppercase tracking-[0.24em] text-blue-500">
             Application

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -1,0 +1,292 @@
+import { CheckCircle2, FileText, ShieldCheck } from "lucide-react";
+import { FormEvent, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+
+type LoanApplyConfig = {
+  name: string;
+  subtitle: string;
+  limit: string;
+  period: string;
+  rate: string;
+  defaultAmount: string;
+  defaultPurpose: string;
+};
+
+type StoredLoanApplication = {
+  applicationId: string;
+  productId: string;
+  productName: string;
+  status: string;
+  appliedAt: string;
+  requestedAmount: string;
+  loanTerm: string;
+  purpose: string;
+};
+
+const LOAN_APPLICATIONS_KEY = "loanApplications";
+
+const productConfigs: Record<string, LoanApplyConfig> = {
+  "consumption-loan": {
+    name: "소비분석 대출",
+    subtitle: "소비 흐름을 기준으로 자금 운용 부담을 조절할 수 있는 상품입니다.",
+    limit: "최대 300만원",
+    period: "6개월 ~ 18개월",
+    rate: "연 4.2% ~ 8.9%",
+    defaultAmount: "2000000",
+    defaultPurpose: "생활비 및 소비 관리",
+  },
+  "youth-loan": {
+    name: "자기계발 대출",
+    subtitle: "자격증, 어학, 직무 교육 등 자기계발 비용을 준비하는 청년 대상 상품입니다.",
+    limit: "최대 500만원",
+    period: "12개월 ~ 24개월",
+    rate: "연 3.8% ~ 6.2%",
+    defaultAmount: "3000000",
+    defaultPurpose: "자격증 및 직무 교육 준비",
+  },
+  "situate-loan": {
+    name: "비상금 대출",
+    subtitle: "갑작스러운 지출에 빠르게 대응할 수 있는 소액 단기 상품입니다.",
+    limit: "최대 200만원",
+    period: "1개월 ~ 12개월",
+    rate: "연 5.1% ~ 9.9%",
+    defaultAmount: "1000000",
+    defaultPurpose: "단기 긴급 자금",
+  },
+};
+
+function readLoanApplications() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(raw) as StoredLoanApplication[];
+  } catch {
+    return [];
+  }
+}
+
+export default function LoanApply() {
+  const navigate = useNavigate();
+  const { productId } = useParams<{ productId: string }>();
+  const product = productId ? productConfigs[productId] : undefined;
+  const existingApplications = useMemo(readLoanApplications, []);
+  const existing = existingApplications.find((item) => item.productId === productId) ?? null;
+
+  const [amount, setAmount] = useState(product?.defaultAmount ?? "");
+  const [loanTerm, setLoanTerm] = useState(productId === "youth-loan" ? "24개월" : "12개월");
+  const [purpose, setPurpose] = useState(product?.defaultPurpose ?? "");
+  const [agreeTerms, setAgreeTerms] = useState(false);
+  const [agreePrivacy, setAgreePrivacy] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!productId || !product) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-12">
+        <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center shadow-lg">
+          <h1 className="text-2xl font-bold text-slate-900">신청할 상품을 찾을 수 없습니다</h1>
+          <Link
+            to="/loan/products"
+            className="mt-4 inline-block font-semibold text-blue-600 hover:underline"
+          >
+            대출 상품 목록으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError("");
+
+    if (!agreeTerms || !agreePrivacy) {
+      setError("약관 동의와 개인정보 동의를 모두 체크해 주세요.");
+      return;
+    }
+
+    const nextApplications = existing
+      ? existingApplications
+      : [
+          ...existingApplications,
+          {
+            applicationId: `APP-${Date.now()}`,
+            productId,
+            productName: product.name,
+            status: productId === "youth-loan" ? "DOCUMENT_REQUIRED" : "UNDER_REVIEW",
+            appliedAt: new Date().toISOString(),
+            requestedAmount: amount,
+            loanTerm,
+            purpose,
+          },
+        ];
+
+    window.localStorage.setItem(LOAN_APPLICATIONS_KEY, JSON.stringify(nextApplications));
+    window.dispatchEvent(new Event("loan-application-change"));
+    navigate("/loan/management");
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-12">
+      <div className="mb-8">
+        <Link
+          to={`/loan/products/${productId}`}
+          className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 font-semibold text-white shadow-sm backdrop-blur-sm transition-colors hover:bg-white/20"
+        >
+          ← 상품 상세로 돌아가기
+        </Link>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-blue-500">
+            Application
+          </p>
+          <h1 className="mt-2 text-3xl font-bold text-slate-900">{product.name} 신청</h1>
+          <p className="mt-3 text-slate-600">{product.subtitle}</p>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-sm font-medium text-slate-600">한도</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{product.limit}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-sm font-medium text-slate-600">기간</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{product.period}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-sm font-medium text-slate-600">금리</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{product.rate}</p>
+            </div>
+          </div>
+
+          <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-slate-600">신청 금액</label>
+              <input
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
+                className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+                placeholder="신청 금액을 입력해 주세요"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-slate-600">상환 기간</label>
+              <select
+                value={loanTerm}
+                onChange={(event) => setLoanTerm(event.target.value)}
+                className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+              >
+                <option>12개월</option>
+                <option>18개월</option>
+                <option>24개월</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-slate-600">신청 목적</label>
+              <textarea
+                value={purpose}
+                onChange={(event) => setPurpose(event.target.value)}
+                className="min-h-32 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+              />
+            </div>
+
+            <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+              <label className="flex items-start gap-3 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={agreeTerms}
+                  onChange={(event) => setAgreeTerms(event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-slate-300"
+                />
+                <span>대출 상품 설명서 및 약관 내용을 확인했고 이에 동의합니다.</span>
+              </label>
+              <label className="flex items-start gap-3 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={agreePrivacy}
+                  onChange={(event) => setAgreePrivacy(event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-slate-300"
+                />
+                <span>대출 심사를 위한 개인정보 수집 및 이용에 동의합니다.</span>
+              </label>
+            </div>
+
+            {error && (
+              <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="w-full rounded-2xl bg-[#6d8ca6] py-4 font-semibold text-white shadow-md transition hover:bg-[#5c7c97]"
+            >
+              대출 신청 완료
+            </button>
+          </form>
+        </section>
+
+        <aside className="space-y-4">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <div className="flex items-center gap-3">
+              <div className="rounded-full bg-blue-100 p-3 text-blue-600">
+                <FileText className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-slate-600">신청 절차</p>
+                <h2 className="text-lg font-bold text-slate-900">진행 순서</h2>
+              </div>
+            </div>
+            <div className="mt-5 space-y-3 text-sm leading-6 text-slate-700">
+              <p>1. 상품 조건 확인</p>
+              <p>2. 약관 동의 및 신청 정보 입력</p>
+              <p>3. 신청 완료 후 내 대출 관리에서 상태 확인</p>
+              {productId === "youth-loan" && <p>4. 자기계발 대출은 OCR 서류 제출 진행</p>}
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <div className="flex items-center gap-3">
+              <div className="rounded-full bg-emerald-100 p-3 text-emerald-600">
+                <CheckCircle2 className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-slate-600">확인 사항</p>
+                <h2 className="text-lg font-bold text-slate-900">안내</h2>
+              </div>
+            </div>
+            <div className="mt-5 space-y-3 text-sm leading-6 text-slate-700">
+              <p>신청 후 실제 승인 여부는 심사 결과에 따라 달라질 수 있습니다.</p>
+              <p>자기계발 대출은 신청 후 내 대출 관리에서 OCR 인증을 진행합니다.</p>
+              <p>소비분석 대출은 신청 후 바로 심사 상태를 조회할 수 있습니다.</p>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+            <div className="flex items-center gap-3">
+              <div className="rounded-full bg-slate-200 p-3 text-slate-700">
+                <ShieldCheck className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-slate-600">보안 안내</p>
+                <h2 className="text-lg font-bold text-slate-900">개인정보 보호</h2>
+              </div>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-slate-700">
+              신청 정보는 브라우저 임시 저장 상태로 관리되고 있으며, 백엔드 연동 이후 실제 신청 데이터와 연결됩니다.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle2, FileText, ShieldCheck } from "lucide-react";
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
+import { postJson } from "../../lib/api";
 
 type LoanApplyConfig = {
   name: string;
@@ -12,18 +13,15 @@ type LoanApplyConfig = {
   defaultPurpose: string;
 };
 
-type StoredLoanApplication = {
-  applicationId: string;
-  productId: string;
+type LoanApplicationSummary = {
+  loanApplicationId: number;
+  productKey: string;
   productName: string;
-  status: string;
+  applicationStatus: string;
   appliedAt: string;
-  requestedAmount: string;
-  loanTerm: string;
-  purpose: string;
+  requiresCertificateSubmission: boolean;
+  certificateSubmitted: boolean;
 };
-
-const LOAN_APPLICATIONS_KEY = "loanApplications";
 
 const productConfigs: Record<string, LoanApplyConfig> = {
   "consumption-loan": {
@@ -55,36 +53,17 @@ const productConfigs: Record<string, LoanApplyConfig> = {
   },
 };
 
-function readLoanApplications() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    return JSON.parse(raw) as StoredLoanApplication[];
-  } catch {
-    return [];
-  }
-}
-
 export default function LoanApply() {
   const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
   const product = productId ? productConfigs[productId] : undefined;
-  const existingApplications = useMemo(readLoanApplications, []);
-  const existing = existingApplications.find((item) => item.productId === productId) ?? null;
-
   const [amount, setAmount] = useState(product?.defaultAmount ?? "");
   const [loanTerm, setLoanTerm] = useState(productId === "youth-loan" ? "24개월" : "12개월");
   const [purpose, setPurpose] = useState(product?.defaultPurpose ?? "");
   const [agreeTerms, setAgreeTerms] = useState(false);
   const [agreePrivacy, setAgreePrivacy] = useState(false);
   const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   if (!productId || !product) {
     return (
@@ -102,7 +81,7 @@ export default function LoanApply() {
     );
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError("");
 
@@ -111,25 +90,27 @@ export default function LoanApply() {
       return;
     }
 
-    const nextApplications = existing
-      ? existingApplications
-      : [
-          ...existingApplications,
-          {
-            applicationId: `APP-${Date.now()}`,
-            productId,
-            productName: product.name,
-            status: productId === "youth-loan" ? "DOCUMENT_REQUIRED" : "UNDER_REVIEW",
-            appliedAt: new Date().toISOString(),
-            requestedAmount: amount,
-            loanTerm,
-            purpose,
-          },
-        ];
+    if (!productId) {
+      return;
+    }
 
-    window.localStorage.setItem(LOAN_APPLICATIONS_KEY, JSON.stringify(nextApplications));
-    window.dispatchEvent(new Event("loan-application-change"));
-    navigate("/loan/management");
+    setIsSubmitting(true);
+    try {
+      await postJson<LoanApplicationSummary>("/api/loan-applications", {
+        productKey: productId,
+        loanAmount: Number(amount),
+        loanTerm,
+        monthlyIncome: 2500000,
+        salaryDate: 25,
+        purpose,
+      });
+      window.dispatchEvent(new Event("loan-application-change"));
+      navigate("/loan/management");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "대출 신청에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -228,9 +209,10 @@ export default function LoanApply() {
 
             <button
               type="submit"
+              disabled={isSubmitting}
               className="w-full rounded-2xl bg-[#6d8ca6] py-4 font-semibold text-white shadow-md transition hover:bg-[#5c7c97]"
             >
-              대출 신청 완료
+              {isSubmitting ? "신청 처리 중..." : "대출 신청 완료"}
             </button>
           </form>
         </section>

--- a/src/app/pages/loan/LoanDetail.tsx
+++ b/src/app/pages/loan/LoanDetail.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
+import { getJson } from "../../lib/api";
 
 type LoanDetailItem = {
   name: string;
@@ -23,17 +24,17 @@ type LoanDetailItem = {
   terms: string[];
 };
 
-type StoredLoanApplication = {
-  applicationId: string;
-  productId: string;
+type LoanApplicationSummary = {
+  loanApplicationId: number;
+  productKey: string;
   productName: string;
-  status: string;
+  applicationStatus: string;
   appliedAt: string;
+  requiresCertificateSubmission: boolean;
+  certificateSubmitted: boolean;
 };
 
 type DetailTab = "guide" | "rate" | "terms" | "caution";
-
-const LOAN_APPLICATIONS_KEY = "loanApplications";
 
 const loanDetails: Record<string, LoanDetailItem> = {
   "consumption-loan": {
@@ -130,53 +131,51 @@ const tabs: { id: DetailTab; label: string }[] = [
   { id: "caution", label: "유의사항" },
 ];
 
-function readLoanApplications() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    return JSON.parse(raw) as StoredLoanApplication[];
-  } catch {
-    return [];
-  }
-}
-
 export default function LoanDetail() {
   const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
   const product = productId ? loanDetails[productId] : undefined;
-  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+  const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
   const [activeTab, setActiveTab] = useState<DetailTab>("guide");
 
   useEffect(() => {
-    const syncApplications = () => {
-      setApplications(readLoanApplications());
+    const syncApplications = async () => {
+      if (localStorage.getItem("isLoggedIn") !== "true") {
+        setApplications([]);
+        return;
+      }
+
+      try {
+        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        setApplications(nextApplications);
+      } catch {
+        setApplications([]);
+      }
     };
 
-    syncApplications();
-    window.addEventListener("storage", syncApplications);
+    void syncApplications();
+    window.addEventListener("auth-change", syncApplications);
     window.addEventListener("loan-application-change", syncApplications);
 
     return () => {
-      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("auth-change", syncApplications);
       window.removeEventListener("loan-application-change", syncApplications);
     };
   }, []);
 
   const application = useMemo(
-    () => applications.find((item) => item.productId === productId) ?? null,
+    () => applications.find((item) => item.productKey === productId) ?? null,
     [applications, productId],
   );
 
   const handlePrimaryAction = () => {
     if (!productId || !product) {
       navigate("/loan/products");
+      return;
+    }
+
+    if (application) {
+      navigate("/loan/management");
       return;
     }
 
@@ -263,7 +262,7 @@ export default function LoanDetail() {
           onClick={handlePrimaryAction}
           className="rounded-xl bg-[#6d8ca6] px-8 py-3 font-semibold text-white shadow-md transition-all hover:bg-[#5c7c97]"
         >
-          대출 신청하기
+          {application ? "내 대출 관리 보기" : "대출 신청하기"}
         </button>
       </div>
 

--- a/src/app/pages/loan/LoanDetail.tsx
+++ b/src/app/pages/loan/LoanDetail.tsx
@@ -131,6 +131,25 @@ const tabs: { id: DetailTab; label: string }[] = [
   { id: "caution", label: "유의사항" },
 ];
 
+function getApplicationStatusLabel(application: LoanApplicationSummary) {
+  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
+    return "서류 제출 완료";
+  }
+
+  switch (application.applicationStatus) {
+    case "DOCUMENT_REQUIRED":
+      return "서류 제출 필요";
+    case "UNDER_REVIEW":
+      return "심사 진행 중";
+    case "APPROVED":
+      return "이용 중";
+    case "REJECTED":
+      return "심사 반려";
+    default:
+      return "접수 완료";
+  }
+}
+
 export default function LoanDetail() {
   const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
@@ -252,10 +271,17 @@ export default function LoanDetail() {
 
       <div className="mb-8 rounded-3xl border border-[#d7e5f5] bg-[linear-gradient(135deg,_#edf4fb_0%,_#dfeefb_50%,_#f8fbff_100%)] p-8 text-center text-slate-900 shadow-xl">
         <h3 className="mb-2 text-2xl font-bold">상품 내용을 확인한 뒤 바로 신청할 수 있습니다</h3>
+        {application && (
+          <div className="mb-4 inline-flex rounded-full border border-emerald-600/70 bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
+            {getApplicationStatusLabel(application)}
+          </div>
+        )}
         <p className="mb-6 text-slate-600">
           {productId === "youth-loan"
             ? "자기계발 대출은 신청 후 내 대출 관리에서 OCR 서류를 제출하면 심사가 이어집니다."
-            : "소비분석 대출은 신청 후 심사 상태를 내 대출 관리에서 바로 확인할 수 있습니다."}
+            : productId === "consumption-loan"
+              ? "소비분석 대출은 신청 후 심사 상태를 내 대출 관리에서 바로 확인할 수 있습니다."
+              : "비상금 대출은 신청 후 심사 상태와 상환 일정을 내 대출 관리에서 확인할 수 있습니다."}
         </p>
         <button
           type="button"

--- a/src/app/pages/loan/LoanDetail.tsx
+++ b/src/app/pages/loan/LoanDetail.tsx
@@ -1,47 +1,194 @@
-import { useParams, Link } from "react-router";
-import { Percent, Users, Coins, Calendar, AlertCircle, FileText, Info } from "lucide-react";
+import {
+  AlertCircle,
+  Calendar,
+  Coins,
+  FileText,
+  Info,
+  Percent,
+  Users,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
 
-const loanDetails = {
+type LoanDetailItem = {
+  name: string;
+  description: string;
+  features: string[];
+  target: string;
+  limit: string;
+  period: string;
+  rate: string;
+  caution: string[];
+  guide: string[];
+  terms: string[];
+};
+
+type StoredLoanApplication = {
+  applicationId: string;
+  productId: string;
+  productName: string;
+  status: string;
+  appliedAt: string;
+};
+
+type DetailTab = "guide" | "rate" | "terms" | "caution";
+
+const LOAN_APPLICATIONS_KEY = "loanApplications";
+
+const loanDetails: Record<string, LoanDetailItem> = {
   "consumption-loan": {
-    name: "소비연동형 자동상환 대출",
-    description: "AI 기술로 소비 패턴을 분석하여 자동으로 대출을 상환하는 혁신적인 대출 상품",
+    name: "소비분석 대출",
+    description:
+      "소비 흐름과 월별 지출 패턴을 기준으로 자금 운용 부담을 조절할 수 있도록 설계한 상품입니다.",
     features: [
-      "AI 소비 분석을 통한 맞춤형 상환 계획",
-      "생필품 소비는 자동 상환 제외",
-      "사치품 소비 시 자동으로 일부 상환",
-      "신용점수 관리에 도움",
+      "소비 분석 기반 상담",
+      "최대 300만원 한도",
+      "자동이체 연계 가능",
+      "중도상환수수료 없음",
     ],
-    target: "만 19세 이상 개인 고객",
-    limit: "최소 500만원 ~ 최대 5,000만원",
-    period: "1년 ~ 5년 (12개월 단위)",
-    rate: "연 3.5% ~ 7.5% (고객 신용도에 따라 차등 적용)",
+    target: "소비 흐름 관리가 필요한 고객",
+    limit: "최소 50만원 ~ 최대 300만원",
+    period: "6개월 ~ 18개월",
+    rate: "연 4.2% ~ 8.9%",
+    guide: [
+      "월별 소비 패턴을 기준으로 자금 운용 부담을 조절할 수 있도록 설계했습니다.",
+      "지출 흐름을 함께 관리하는 상품으로 생활비 목적 자금에 적합합니다.",
+      "신청 후 심사 상태는 내 대출 관리에서 확인할 수 있습니다.",
+    ],
+    terms: [
+      "대출금은 약정한 목적과 범위 내에서 사용해야 합니다.",
+      "상환 계좌와 일정은 심사 완료 후 확정됩니다.",
+      "상품 설명서와 약관 확인 후 신청해 주세요.",
+    ],
+    caution: [
+      "개인의 신용도와 거래 조건에 따라 한도와 금리가 달라질 수 있습니다.",
+      "연체 발생 시 약정 금리에 연체이자가 가산될 수 있습니다.",
+      "과도한 대출은 상환 부담을 높일 수 있습니다.",
+    ],
   },
   "youth-loan": {
-    name: "청년 자기계발 대출",
-    description: "청년의 미래를 응원하는 특별 금리 대출 상품",
+    name: "자기계발 대출",
+    description:
+      "20대 청년이 자격증, 어학, 직무 교육 등 자기계발에 필요한 비용을 준비할 수 있도록 설계한 상품입니다.",
     features: [
-      "만 34세 이하 청년 전용 특별 금리",
-      "교육비, 자격증, 어학 연수 등 자기계발 용도",
-      "1년 거치 후 원리금 균등 상환",
-      "중도 상환 수수료 면제",
+      "자격증, 어학, 실무 교육 비용 지원",
+      "최대 500만원 한도",
+      "최대 24개월 상환",
+      "신청 후 내 대출 관리에서 OCR 서류 제출",
     ],
-    target: "만 19세 ~ 만 34세 청년",
-    limit: "최소 300만원 ~ 최대 3,000만원",
-    period: "1년 ~ 3년 (거치 기간 1년 포함)",
-    rate: "연 2.5% ~ 4.5% (청년 우대 금리 적용)",
+    target: "만 19세 ~ 29세 청년 고객",
+    limit: "최소 50만원 ~ 최대 500만원",
+    period: "12개월 ~ 24개월",
+    rate: "연 3.8% ~ 6.2%",
+    guide: [
+      "자격증, 어학, 실무 교육 등 자기계발 목적에 맞는 자금을 지원합니다.",
+      "대출 신청 후 내 대출 관리에서 서류를 제출하면 심사가 이어집니다.",
+      "OCR 인증 결과에 따라 추가 확인 절차가 진행될 수 있습니다.",
+    ],
+    terms: [
+      "자기계발 목적을 증빙할 수 있는 서류 제출이 필요합니다.",
+      "상품 설명서와 약관을 확인한 뒤 신청해 주세요.",
+      "심사 결과에 따라 최종 승인 여부와 한도는 달라질 수 있습니다.",
+    ],
+    caution: [
+      "대출 신청 후 자기계발 증빙 서류를 제출해야 심사가 진행됩니다.",
+      "서류 제출 및 OCR 인증 결과에 따라 추가 확인이 필요할 수 있습니다.",
+      "개인의 신용도와 심사 결과에 따라 최종 승인 여부가 달라질 수 있습니다.",
+    ],
+  },
+  "situate-loan": {
+    name: "비상금 대출",
+    description:
+      "갑작스러운 지출에 빠르게 대응할 수 있도록 소액 한도를 제공하는 단기 자금 상품입니다.",
+    features: ["최대 200만원", "단기 자금 대응", "모바일 신청", "빠른 실행"],
+    target: "소액 단기 자금이 필요한 고객",
+    limit: "최소 30만원 ~ 최대 200만원",
+    period: "1개월 ~ 12개월",
+    rate: "연 5.1% ~ 9.9%",
+    guide: [
+      "갑작스러운 생활비와 긴급 자금 수요에 대응하기 위한 상품입니다.",
+      "짧은 기간 안에 빠르게 실행할 수 있도록 단순한 구조로 설계했습니다.",
+      "모바일 신청 후 상태를 바로 확인할 수 있습니다.",
+    ],
+    terms: [
+      "실행 한도와 금리는 심사 결과에 따라 달라질 수 있습니다.",
+      "상환 일정과 계좌는 승인 후 확정됩니다.",
+      "약정 전 상품 설명서와 약관을 반드시 확인해 주세요.",
+    ],
+    caution: [
+      "필요 이상으로 반복 사용하면 상환 부담이 커질 수 있습니다.",
+      "연체 시 개인 신용점수에 부정적인 영향이 발생할 수 있습니다.",
+      "약정 전 상품 설명서와 유의사항을 반드시 확인해 주세요.",
+    ],
   },
 };
 
+const tabs: { id: DetailTab; label: string }[] = [
+  { id: "guide", label: "상품 안내" },
+  { id: "rate", label: "금리 안내" },
+  { id: "terms", label: "약관 및 설명서" },
+  { id: "caution", label: "유의사항" },
+];
+
+function readLoanApplications() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(raw) as StoredLoanApplication[];
+  } catch {
+    return [];
+  }
+}
+
 export default function LoanDetail() {
+  const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
-  const product = loanDetails[productId as keyof typeof loanDetails];
+  const product = productId ? loanDetails[productId] : undefined;
+  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+  const [activeTab, setActiveTab] = useState<DetailTab>("guide");
+
+  useEffect(() => {
+    const syncApplications = () => {
+      setApplications(readLoanApplications());
+    };
+
+    syncApplications();
+    window.addEventListener("storage", syncApplications);
+    window.addEventListener("loan-application-change", syncApplications);
+
+    return () => {
+      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("loan-application-change", syncApplications);
+    };
+  }, []);
+
+  const application = useMemo(
+    () => applications.find((item) => item.productId === productId) ?? null,
+    [applications, productId],
+  );
+
+  const handlePrimaryAction = () => {
+    if (!productId || !product) {
+      navigate("/loan/products");
+      return;
+    }
+
+    navigate(`/loan/products/${productId}/apply`);
+  };
 
   if (!product) {
     return (
-      <div className="max-w-7xl mx-auto px-4 py-12">
-        <div className="text-center bg-white/95 backdrop-blur-md p-8 rounded-lg shadow-2xl border border-white/20">
-          <h1 className="text-2xl font-bold mb-4 text-gray-900">상품을 찾을 수 없습니다</h1>
-          <Link to="/loan/products" className="text-blue-600 hover:underline font-semibold">
+      <div className="mx-auto max-w-7xl px-4 py-12">
+        <div className="rounded-lg border border-white/20 bg-white/95 p-8 text-center shadow-2xl backdrop-blur-md">
+          <h1 className="mb-4 text-2xl font-bold text-gray-900">상품을 찾을 수 없습니다</h1>
+          <Link to="/loan/products" className="font-semibold text-blue-600 hover:underline">
             대출 상품 목록으로 돌아가기
           </Link>
         </div>
@@ -50,137 +197,164 @@ export default function LoanDetail() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-12">
-      {/* 상품명 */}
+    <div className="mx-auto max-w-7xl px-4 py-12">
       <div className="mb-8">
-        <Link to="/loan/products" className="text-blue-300 hover:text-white mb-4 inline-block font-semibold transition-colors">
+        <Link
+          to="/loan/products"
+          className="mb-4 inline-block font-semibold text-blue-300 transition-colors hover:text-white"
+        >
           ← 대출 상품 목록
         </Link>
-        <h1 className="text-4xl font-bold mb-4 text-white drop-shadow-lg">{product.name}</h1>
+        <h1 className="mb-4 text-4xl font-bold text-white drop-shadow-lg">{product.name}</h1>
         <p className="text-xl text-blue-100 drop-shadow-md">{product.description}</p>
       </div>
 
-      {/* 주요 정보 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-        <div className="bg-white/95 backdrop-blur-md p-6 rounded-lg shadow-2xl border border-white/20">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="bg-blue-100 p-2 rounded">
-              <AlertCircle className="w-5 h-5 text-blue-600" />
+      <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div className="rounded-lg border border-white/20 bg-white/95 p-6 shadow-2xl backdrop-blur-md">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="rounded bg-blue-100 p-2">
+              <AlertCircle className="h-5 w-5 text-blue-600" />
             </div>
             <h3 className="font-bold text-gray-900">특징</h3>
           </div>
-          <p className="text-gray-600 text-sm">{product.features.length}가지 혜택</p>
+          <p className="text-sm text-gray-600">{product.features.length}가지 핵심 조건</p>
         </div>
 
-        <div className="bg-white/95 backdrop-blur-md p-6 rounded-lg shadow-2xl border border-white/20">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="bg-blue-100 p-2 rounded">
-              <Users className="w-5 h-5 text-blue-600" />
+        <div className="rounded-lg border border-white/20 bg-white/95 p-6 shadow-2xl backdrop-blur-md">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="rounded bg-blue-100 p-2">
+              <Users className="h-5 w-5 text-blue-600" />
             </div>
             <h3 className="font-bold text-gray-900">대상</h3>
           </div>
-          <p className="text-gray-600 text-sm">{product.target}</p>
+          <p className="text-sm text-gray-600">{product.target}</p>
         </div>
 
-        <div className="bg-white/95 backdrop-blur-md p-6 rounded-lg shadow-2xl border border-white/20">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="bg-blue-100 p-2 rounded">
-              <Coins className="w-5 h-5 text-blue-600" />
+        <div className="rounded-lg border border-white/20 bg-white/95 p-6 shadow-2xl backdrop-blur-md">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="rounded bg-blue-100 p-2">
+              <Coins className="h-5 w-5 text-blue-600" />
             </div>
             <h3 className="font-bold text-gray-900">한도</h3>
           </div>
-          <p className="text-gray-600 text-sm">{product.limit}</p>
+          <p className="text-sm text-gray-600">{product.limit}</p>
         </div>
 
-        <div className="bg-white/95 backdrop-blur-md p-6 rounded-lg shadow-2xl border border-white/20">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="bg-blue-100 p-2 rounded">
-              <Calendar className="w-5 h-5 text-blue-600" />
+        <div className="rounded-lg border border-white/20 bg-white/95 p-6 shadow-2xl backdrop-blur-md">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="rounded bg-blue-100 p-2">
+              <Calendar className="h-5 w-5 text-blue-600" />
             </div>
             <h3 className="font-bold text-gray-900">기간</h3>
           </div>
-          <p className="text-gray-600 text-sm">{product.period}</p>
+          <p className="text-sm text-gray-600">{product.period}</p>
         </div>
       </div>
 
-      {/* 상담 신청 버튼 */}
-      <div className="bg-gradient-to-r from-blue-600 to-blue-800 text-white p-8 rounded-lg mb-8 text-center shadow-2xl backdrop-blur-md border border-white/20">
-        <h3 className="text-2xl font-bold mb-2">지금 바로 상담 신청하세요</h3>
-        <p className="mb-6 text-blue-100">전문 상담사가 맞춤 상담을 제공합니다</p>
-        <button className="bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-all shadow-lg">
-          상담 신청하기
+      <div className="mb-8 rounded-3xl border border-[#d7e5f5] bg-[linear-gradient(135deg,_#edf4fb_0%,_#dfeefb_50%,_#f8fbff_100%)] p-8 text-center text-slate-900 shadow-xl">
+        <h3 className="mb-2 text-2xl font-bold">상품 내용을 확인한 뒤 바로 신청할 수 있습니다</h3>
+        <p className="mb-6 text-slate-600">
+          {productId === "youth-loan"
+            ? "자기계발 대출은 신청 후 내 대출 관리에서 OCR 서류를 제출하면 심사가 이어집니다."
+            : "소비분석 대출은 신청 후 심사 상태를 내 대출 관리에서 바로 확인할 수 있습니다."}
+        </p>
+        <button
+          type="button"
+          onClick={handlePrimaryAction}
+          className="rounded-xl bg-[#6d8ca6] px-8 py-3 font-semibold text-white shadow-md transition-all hover:bg-[#5c7c97]"
+        >
+          대출 신청하기
         </button>
       </div>
 
-      {/* 탭 섹션 */}
-      <div className="bg-white/95 backdrop-blur-md rounded-lg shadow-2xl border border-white/20">
+      <div className="rounded-lg border border-white/20 bg-white/95 shadow-2xl backdrop-blur-md">
         <div className="border-b border-gray-200">
-          <div className="flex">
-            <button className="px-6 py-4 font-semibold text-blue-600 border-b-2 border-blue-600">
-              상품안내
-            </button>
-            <button className="px-6 py-4 font-semibold text-gray-500 hover:text-gray-700">
-              금리안내
-            </button>
-            <button className="px-6 py-4 font-semibold text-gray-500 hover:text-gray-700">
-              약관 및 상품설명서
-            </button>
-            <button className="px-6 py-4 font-semibold text-gray-500 hover:text-gray-700">
-              유의사항 및 기타
-            </button>
+          <div className="flex flex-wrap">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={
+                  activeTab === tab.id
+                    ? "border-b-2 border-blue-600 px-6 py-4 font-semibold text-blue-600"
+                    : "px-6 py-4 font-semibold text-gray-500 hover:text-gray-700"
+                }
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
         </div>
 
         <div className="p-8">
-          {/* 상품안내 */}
-          <section className="mb-8">
-            <h3 className="text-xl font-bold mb-4 flex items-center gap-2 text-gray-900">
-              <Info className="w-5 h-5 text-blue-600" />
-              상품 특징
-            </h3>
-            <ul className="space-y-3">
-              {product.features.map((feature, index) => (
-                <li key={index} className="flex items-start gap-3">
-                  <div className="w-1.5 h-1.5 bg-blue-600 rounded-full mt-2"></div>
-                  <span className="text-gray-700">{feature}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          {/* 금리안내 */}
-          <section className="mb-8">
-            <h3 className="text-xl font-bold mb-4 flex items-center gap-2 text-gray-900">
-              <Percent className="w-5 h-5 text-blue-600" />
-              금리 정보
-            </h3>
-            <div className="bg-gray-50/80 backdrop-blur-sm p-6 rounded-lg border border-gray-200">
-              <div className="flex justify-between items-center mb-4">
-                <span className="text-gray-700">기본 금리</span>
-                <span className="font-bold text-xl text-gray-900">{product.rate}</span>
-              </div>
-              <p className="text-sm text-gray-600">
-                ※ 실제 적용 금리는 고객님의 신용도, 거래실적 등에 따라 달라질 수 있습니다.
-              </p>
-            </div>
-          </section>
-
-          {/* 유의사항 */}
-          <section>
-            <h3 className="text-xl font-bold mb-4 flex items-center gap-2 text-gray-900">
-              <FileText className="w-5 h-5 text-blue-600" />
-              유의사항
-            </h3>
-            <div className="bg-yellow-50/80 backdrop-blur-sm border border-yellow-200 p-6 rounded-lg">
-              <ul className="space-y-2 text-sm text-gray-700">
-                <li>• 대출 실행 후 중도상환 시 수수료가 발생할 수 있습니다.</li>
-                <li>• 개인 신용평점이 하락할 수 있으니 신중하게 이용하시기 바랍니다.</li>
-                <li>• 과도한 대출은 개인신용평점 하락의 원인이 될 수 있습니다.</li>
-                <li>• 귀하의 신용등급 또는 개인신용평점이 하락할 수 있습니다.</li>
-                <li>• 연체 시 신용등급 또는 개인신용평점이 하락할 수 있습니다.</li>
+          {activeTab === "guide" && (
+            <section>
+              <h3 className="mb-4 flex items-center gap-2 text-xl font-bold text-gray-900">
+                <Info className="h-5 w-5 text-blue-600" />
+                상품 특징
+              </h3>
+              <ul className="space-y-3">
+                {product.guide.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <div className="mt-2 h-1.5 w-1.5 rounded-full bg-blue-600" />
+                    <span className="text-gray-700">{item}</span>
+                  </li>
+                ))}
               </ul>
-            </div>
-          </section>
+            </section>
+          )}
+
+          {activeTab === "rate" && (
+            <section>
+              <h3 className="mb-4 flex items-center gap-2 text-xl font-bold text-gray-900">
+                <Percent className="h-5 w-5 text-blue-600" />
+                금리 정보
+              </h3>
+              <div className="rounded-lg border border-gray-200 bg-gray-50/80 p-6 backdrop-blur-sm">
+                <div className="mb-4 flex items-center justify-between">
+                  <span className="text-gray-700">적용 금리</span>
+                  <span className="text-xl font-bold text-gray-900">{product.rate}</span>
+                </div>
+                <p className="text-sm text-gray-600">
+                  실제 적용 금리는 신용도, 심사 결과, 거래 조건에 따라 달라질 수 있습니다.
+                </p>
+              </div>
+            </section>
+          )}
+
+          {activeTab === "terms" && (
+            <section>
+              <h3 className="mb-4 flex items-center gap-2 text-xl font-bold text-gray-900">
+                <FileText className="h-5 w-5 text-blue-600" />
+                약관 및 설명서
+              </h3>
+              <ul className="space-y-3">
+                {product.terms.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <div className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-400" />
+                    <span className="text-gray-700">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {activeTab === "caution" && (
+            <section>
+              <h3 className="mb-4 flex items-center gap-2 text-xl font-bold text-gray-900">
+                <FileText className="h-5 w-5 text-blue-600" />
+                유의사항
+              </h3>
+              <div className="rounded-lg border border-yellow-200 bg-yellow-50/80 p-6 backdrop-blur-sm">
+                <ul className="space-y-2 text-sm text-gray-700">
+                  {product.caution.map((item) => (
+                    <li key={item}>• {item}</li>
+                  ))}
+                </ul>
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -1,183 +1,267 @@
-import { Link } from "react-router";
-import { CheckCircle2, ArrowLeft } from "lucide-react";
-import backgroundImg from "figma:asset/a1fdfd62e9258f5117d1a2174261b21bd02d7d66.png";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router";
 
-const loanProducts = [
+type LoanProduct = {
+  id: string;
+  name: string;
+  badge?: string;
+  rate: string;
+  limit: string;
+  period: string;
+  target: string;
+  summary: string;
+  features: string[];
+  isPrimary: boolean;
+};
+
+type StoredLoanApplication = {
+  applicationId: string;
+  productId: string;
+  productName: string;
+  status: string;
+  appliedAt: string;
+};
+
+const LOAN_APPLICATIONS_KEY = "loanApplications";
+
+const loanProducts: LoanProduct[] = [
   {
     id: "consumption-loan",
-    name: "소비연동형 자동상환 대출",
-    badge: "피커금리",
-    rateMin: "3.2",
-    rateMax: "8.5",
-    limit: "3억원",
-    period: "1년 ~ 10년",
-    available: "5분 이내",
-    features: ["중도상환수수료 없음", "대출 심사약 24시간", "우대금 선정"],
-    isFeatured: true,
+    name: "소비분석 대출",
+    badge: "분석 기반",
+    rate: "연 4.2% ~ 8.9%",
+    limit: "최대 300만원",
+    period: "6개월 ~ 18개월",
+    target: "소비 흐름 관리가 필요한 고객",
+    summary:
+      "소비 패턴을 바탕으로 자금 운용 부담을 조절할 수 있도록 설계한 상품입니다.",
+    features: ["소비 흐름 점검", "간편 심사", "자동이체 연계"],
+    isPrimary: true,
   },
   {
     id: "youth-loan",
-    name: "맛살론15",
-    rateMin: "15.9",
-    rateMax: null,
-    limit: null,
-    features: ["최대 2천만원", "서민금융진흥원"],
-    isFeatured: false,
+    name: "자기계발 대출",
+    badge: "청년 특화",
+    rate: "연 3.8% ~ 6.2%",
+    limit: "최대 500만원",
+    period: "12개월 ~ 24개월",
+    target: "만 19세 ~ 29세 청년",
+    summary:
+      "자격증, 어학, 직무 교육 등 자기계발 비용을 준비할 수 있도록 지원하는 상품입니다.",
+    features: ["서류 제출형 심사", "중도상환수수료 없음", "OCR 연계"],
+    isPrimary: true,
   },
   {
     id: "situate-loan",
-    name: "시잇트2",
-    rateMin: "4.5",
-    rateMax: "14.9",
-    limit: null,
-    features: ["최대 3천만원", "서울보증보험"],
-    isFeatured: false,
+    name: "비상금 대출",
+    rate: "연 5.1% ~ 9.9%",
+    limit: "최대 200만원",
+    period: "1개월 ~ 12개월",
+    target: "소액 단기 자금 필요 고객",
+    summary: "짧은 기간이지만 빠르게 대응해야 하는 상황을 위한 소액 상품입니다.",
+    features: ["소액 한도", "빠른 실행", "모바일 신청"],
+    isPrimary: false,
   },
 ];
 
+function readLoanApplications() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(raw) as StoredLoanApplication[];
+  } catch {
+    return [];
+  }
+}
+
 export default function LoanProducts() {
-  const featuredProduct = loanProducts.find((p) => p.isFeatured);
-  const otherProducts = loanProducts.filter((p) => !p.isFeatured);
+  const navigate = useNavigate();
+  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+
+  useEffect(() => {
+    const syncApplications = () => {
+      setApplications(readLoanApplications());
+    };
+
+    syncApplications();
+    window.addEventListener("storage", syncApplications);
+    window.addEventListener("loan-application-change", syncApplications);
+
+    return () => {
+      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("loan-application-change", syncApplications);
+    };
+  }, []);
+
+  const primaryProducts = useMemo(
+    () => loanProducts.filter((product) => product.isPrimary),
+    [],
+  );
+  const secondaryProducts = useMemo(
+    () => loanProducts.filter((product) => !product.isPrimary),
+    [],
+  );
+
+  const getApplication = (productId: string) =>
+    applications.find((application) => application.productId === productId) ?? null;
+
+  const handleApply = (product: LoanProduct) => {
+    const existing = getApplication(product.id);
+    if (existing) {
+      navigate("/loan/management");
+      return;
+    }
+
+    navigate(`/loan/products/${product.id}/apply`);
+  };
 
   return (
-    <div className="min-h-screen relative">
-      <div className="max-w-7xl mx-auto px-4 py-12 relative">
-        {/* 헤더 */}
+    <div className="min-h-screen">
+      <div className="mx-auto max-w-7xl px-4 py-12">
         <div className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="bg-white/20 backdrop-blur-md rounded-full p-3 shadow-lg border-2 border-white/30">
-              <CheckCircle2 className="w-8 h-8 text-white" />
+          <div className="mb-4 flex items-center gap-3">
+            <div className="rounded-full border-2 border-white/30 bg-white/20 p-3 shadow-lg backdrop-blur-md">
+              <CheckCircle2 className="h-8 w-8 text-white" />
             </div>
-            <h1 className="text-4xl font-bold text-white drop-shadow-lg">고객님께 딱 맞는 대출 상품을 찾았습니다</h1>
+            <h1 className="text-4xl font-bold text-white drop-shadow-lg">
+              대출상품을 비교하고 바로 신청해보세요
+            </h1>
           </div>
-          <p className="text-xl text-blue-100 ml-16 drop-shadow-lg">3개의 맞춤 상품을 추천드립니다</p>
+          <p className="ml-16 text-xl text-blue-100 drop-shadow-lg">
+            메인 상품 2개를 우선 비교하고, 신청 후에는 내 대출 관리에서 진행 상태를 확인할 수 있습니다.
+          </p>
         </div>
 
-        {/* 메인 컨텐츠 */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
-          {/* 추천 상품 (큰 카드) */}
-          {featuredProduct && (
-            <div className="lg:col-span-2 bg-white/15 backdrop-blur-lg rounded-3xl p-8 shadow-2xl border-2 border-white/30">
-              <div className="flex justify-between items-start mb-6">
-                <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-4">
-                    <h2 className="text-2xl font-bold text-white">
-                      {featuredProduct.name}
-                    </h2>
-                    {featuredProduct.badge && (
-                      <span className="bg-blue-500/30 backdrop-blur-sm text-white px-4 py-1 rounded-full text-sm font-semibold shadow-md border border-white/30">
-                        {featuredProduct.badge}
-                      </span>
-                    )}
-                  </div>
+        <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {primaryProducts.map((product) => {
+            const application = getApplication(product.id);
 
-                  <div className="mb-6">
-                    <div className="text-5xl font-bold text-blue-300 mb-2">
-                      연 {featuredProduct.rateMin}%
-                      {featuredProduct.rateMax && ` ~ ${featuredProduct.rateMax}%`}
-                    </div>
-                  </div>
+            return (
+              <section
+                key={product.id}
+                className="rounded-3xl border-2 border-white/30 bg-white/15 p-8 shadow-2xl backdrop-blur-lg"
+              >
+                <div className="mb-6 flex items-center gap-3">
+                  <h2 className="text-2xl font-bold text-white">{product.name}</h2>
+                  {product.badge && (
+                    <span className="rounded-full border border-white/30 bg-blue-500/30 px-4 py-1 text-sm font-semibold text-white shadow-md backdrop-blur-sm">
+                      {product.badge}
+                    </span>
+                  )}
+                  {application && (
+                    <span className="rounded-full border border-emerald-200/40 bg-emerald-400/20 px-4 py-1 text-sm font-semibold text-emerald-50">
+                      신청 진행 중
+                    </span>
+                  )}
+                </div>
 
-                  <div className="grid grid-cols-3 gap-6 mb-6">
-                    <div>
-                      <p className="text-sm text-blue-200 mb-1">최대 한도</p>
-                      <p className="font-bold text-white">{featuredProduct.limit}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-blue-200 mb-1">상환 방법</p>
-                      <p className="font-bold text-white">{featuredProduct.period}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-blue-200 mb-1">신청 가능+</p>
-                      <p className="font-bold text-white">{featuredProduct.available}</p>
-                    </div>
-                  </div>
+                <p className="mb-6 text-sm leading-6 text-blue-100">{product.summary}</p>
 
-                  <div className="flex flex-wrap gap-2 mb-6">
-                    {featuredProduct.features.map((feature, index) => (
-                      <span
-                        key={index}
-                        className="bg-white/10 backdrop-blur-sm text-white px-4 py-2 rounded-lg text-sm border border-white/20"
-                      >
-                        {feature}
-                      </span>
-                    ))}
+                <div className="mb-6 text-4xl font-bold text-blue-300">{product.rate}</div>
+
+                <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <div>
+                    <p className="mb-1 text-sm text-blue-200">대출 한도</p>
+                    <p className="font-bold text-white">{product.limit}</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-blue-200">상환 기간</p>
+                    <p className="font-bold text-white">{product.period}</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-blue-200">대상</p>
+                    <p className="font-bold text-white">{product.target}</p>
                   </div>
                 </div>
 
-                {/* 3D 그래픽 영역 */}
-                <div className="relative w-64 h-64 flex-shrink-0 ml-6">
-                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-48 h-32 bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] shadow-2xl opacity-90 blur-sm"></div>
-                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-40 h-28 bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] shadow-xl"></div>
-                </div>
-              </div>
-
-              <div className="flex gap-4">
-                <Link
-                  to={`/loan/products/${featuredProduct.id}`}
-                  className="flex-1 bg-white/10 backdrop-blur-sm text-white py-4 rounded-xl font-bold text-center hover:bg-white/20 transition-all shadow-sm border border-white/30"
-                >
-                  상세 보기
-                </Link>
-                <button className="flex-1 bg-blue-500/30 backdrop-blur-sm text-white py-4 rounded-xl font-bold hover:bg-blue-500/40 transition-all shadow-md border border-white/30">
-                  대출 신청하기
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* 다른 상품들 (작은 카드) */}
-          <div className="space-y-6">
-            {otherProducts.map((product) => (
-              <div key={product.id} className="bg-white/15 backdrop-blur-lg rounded-3xl p-6 shadow-2xl border-2 border-white/30">
-                <h3 className="text-xl font-bold text-white mb-4">{product.name}</h3>
-                <div className="text-3xl font-bold text-blue-300 mb-4">
-                  연 {product.rateMin}%
-                  {product.rateMax && ` ~ ${product.rateMax}%`}
-                </div>
-                <div className="space-y-2 mb-6">
-                  {product.features.map((feature, index) => (
-                    <p key={index} className="text-sm text-blue-200">
+                <div className="mb-6 flex flex-wrap gap-2">
+                  {product.features.map((feature) => (
+                    <span
+                      key={feature}
+                      className="rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm text-white backdrop-blur-sm"
+                    >
                       {feature}
-                    </p>
+                    </span>
                   ))}
                 </div>
-                <Link
-                  to={`/loan/products/${product.id}`}
-                  className="block w-full bg-white/10 backdrop-blur-sm text-white py-3 rounded-xl font-bold text-center hover:bg-white/20 transition-all shadow-sm border border-white/30"
-                >
-                  상세 보기
-                </Link>
-              </div>
-            ))}
-          </div>
+
+                <div className="flex flex-col gap-4 sm:flex-row">
+                  <Link
+                    to={`/loan/products/${product.id}`}
+                    className="flex-1 rounded-xl border border-white/30 bg-white/10 py-4 text-center font-bold text-white shadow-sm backdrop-blur-sm transition-all hover:bg-white/20"
+                  >
+                    상세 보기
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => handleApply(product)}
+                    className="flex-1 rounded-xl border border-white/30 bg-blue-500/30 py-4 font-bold text-white shadow-md backdrop-blur-sm transition-all hover:bg-blue-500/40"
+                  >
+                    {application ? "내 대출 관리 보기" : "대출 신청하기"}
+                  </button>
+                </div>
+              </section>
+            );
+          })}
         </div>
 
-        {/* 하단 네비게이션 */}
+        <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {secondaryProducts.map((product) => (
+            <div
+              key={product.id}
+              className="rounded-3xl border-2 border-white/30 bg-white/15 p-6 shadow-2xl backdrop-blur-lg"
+            >
+              <h3 className="mb-4 text-xl font-bold text-white">{product.name}</h3>
+              <div className="mb-2 text-3xl font-bold text-blue-300">{product.rate}</div>
+              <p className="mb-4 text-sm text-blue-100">{product.limit}</p>
+              <div className="mb-6 space-y-2">
+                {product.features.map((feature) => (
+                  <p key={feature} className="text-sm text-blue-200">
+                    {feature}
+                  </p>
+                ))}
+              </div>
+              <Link
+                to={`/loan/products/${product.id}`}
+                className="block w-full rounded-xl border border-white/30 bg-white/10 py-3 text-center font-bold text-white shadow-sm backdrop-blur-sm transition-all hover:bg-white/20"
+              >
+                상세 보기
+              </Link>
+            </div>
+          ))}
+        </div>
+
         <div className="flex items-center justify-between">
-          <button className="flex items-center gap-2 text-white hover:text-blue-200 transition-colors bg-white/10 backdrop-blur-sm px-4 py-2 rounded-lg hover:bg-white/20 border border-white/30">
-            <ArrowLeft className="w-5 h-5" />
-            <span className="font-semibold">다시 상담하기</span>
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-lg border border-white/30 bg-white/10 px-4 py-2 text-white backdrop-blur-sm transition-colors hover:bg-white/20 hover:text-blue-200"
+          >
+            <ArrowLeft className="h-5 w-5" />
+            <span className="font-semibold">다시 둘러보기</span>
           </button>
 
           <div className="flex gap-6 text-sm text-blue-100">
-            <a href="#" className="hover:text-white transition-colors">
+            <a href="#" className="transition-colors hover:text-white">
               이용약관
             </a>
-            <a href="#" className="hover:text-white transition-colors">
+            <a href="#" className="transition-colors hover:text-white">
               개인정보처리방침
             </a>
-            <a href="#" className="hover:text-white transition-colors">
+            <a href="#" className="transition-colors hover:text-white">
               상품공시실
             </a>
-            <a href="#" className="hover:text-white transition-colors">
+            <a href="#" className="transition-colors hover:text-white">
               고객센터
             </a>
           </div>
-        </div>
-
-        <div className="mt-8 text-center text-blue-200 text-sm">
-          © 2025 똑개뱅크. All rights reserved.
         </div>
       </div>
     </div>

--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -26,6 +26,25 @@ type LoanApplicationSummary = {
   certificateSubmitted: boolean;
 };
 
+function getApplicationStatusLabel(application: LoanApplicationSummary) {
+  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
+    return "서류 제출 완료";
+  }
+
+  switch (application.applicationStatus) {
+    case "DOCUMENT_REQUIRED":
+      return "서류 제출 필요";
+    case "UNDER_REVIEW":
+      return "심사 진행 중";
+    case "APPROVED":
+      return "이용 중";
+    case "REJECTED":
+      return "심사 반려";
+    default:
+      return "접수 완료";
+  }
+}
+
 const loanProducts: LoanProduct[] = [
   {
     id: "consumption-loan",
@@ -152,7 +171,7 @@ export default function LoanProducts() {
                   )}
                   {application && (
                     <span className="rounded-full border border-emerald-600/70 bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
-                      접수 완료
+                      {getApplicationStatusLabel(application)}
                     </span>
                   )}
                 </div>
@@ -208,12 +227,22 @@ export default function LoanProducts() {
         </div>
 
         <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
-          {secondaryProducts.map((product) => (
+          {secondaryProducts.map((product) => {
+            const application = getApplication(product.id);
+
+            return (
             <div
               key={product.id}
               className="rounded-3xl border-2 border-white/30 bg-white/15 p-6 shadow-2xl backdrop-blur-lg"
             >
-              <h3 className="mb-4 text-xl font-bold text-white">{product.name}</h3>
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <h3 className="text-xl font-bold text-white">{product.name}</h3>
+                {application && (
+                  <span className="rounded-full border border-emerald-600/70 bg-emerald-600 px-3 py-1 text-xs font-semibold text-white shadow-sm">
+                    {getApplicationStatusLabel(application)}
+                  </span>
+                )}
+              </div>
               <div className="mb-2 text-3xl font-bold text-blue-300">{product.rate}</div>
               <p className="mb-4 text-sm text-blue-100">{product.limit}</p>
               <div className="mb-6 space-y-2">
@@ -229,8 +258,16 @@ export default function LoanProducts() {
               >
                 상세 보기
               </Link>
+              <button
+                type="button"
+                onClick={() => handleApply(product)}
+                className="mt-3 block w-full rounded-xl border border-white/30 bg-blue-500/30 py-3 text-center font-bold text-white shadow-sm backdrop-blur-sm transition-all hover:bg-blue-500/40"
+              >
+                {application ? "내 대출 관리 보기" : "대출 신청하기"}
+              </button>
             </div>
-          ))}
+            );
+          })}
         </div>
 
         <div className="flex items-center justify-between">

--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, CheckCircle2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { getJson } from "../../lib/api";
 
 type LoanProduct = {
   id: string;
@@ -15,15 +16,15 @@ type LoanProduct = {
   isPrimary: boolean;
 };
 
-type StoredLoanApplication = {
-  applicationId: string;
-  productId: string;
+type LoanApplicationSummary = {
+  loanApplicationId: number;
+  productKey: string;
   productName: string;
-  status: string;
+  applicationStatus: string;
   appliedAt: string;
+  requiresCertificateSubmission: boolean;
+  certificateSubmitted: boolean;
 };
-
-const LOAN_APPLICATIONS_KEY = "loanApplications";
 
 const loanProducts: LoanProduct[] = [
   {
@@ -65,38 +66,31 @@ const loanProducts: LoanProduct[] = [
   },
 ];
 
-function readLoanApplications() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    return JSON.parse(raw) as StoredLoanApplication[];
-  } catch {
-    return [];
-  }
-}
-
 export default function LoanProducts() {
   const navigate = useNavigate();
-  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+  const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
 
   useEffect(() => {
-    const syncApplications = () => {
-      setApplications(readLoanApplications());
+    const syncApplications = async () => {
+      if (localStorage.getItem("isLoggedIn") !== "true") {
+        setApplications([]);
+        return;
+      }
+
+      try {
+        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        setApplications(nextApplications);
+      } catch {
+        setApplications([]);
+      }
     };
 
-    syncApplications();
-    window.addEventListener("storage", syncApplications);
+    void syncApplications();
+    window.addEventListener("auth-change", syncApplications);
     window.addEventListener("loan-application-change", syncApplications);
 
     return () => {
-      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("auth-change", syncApplications);
       window.removeEventListener("loan-application-change", syncApplications);
     };
   }, []);
@@ -111,7 +105,7 @@ export default function LoanProducts() {
   );
 
   const getApplication = (productId: string) =>
-    applications.find((application) => application.productId === productId) ?? null;
+    applications.find((application) => application.productKey === productId) ?? null;
 
   const handleApply = (product: LoanProduct) => {
     const existing = getApplication(product.id);
@@ -157,8 +151,8 @@ export default function LoanProducts() {
                     </span>
                   )}
                   {application && (
-                    <span className="rounded-full border border-emerald-200/40 bg-emerald-400/20 px-4 py-1 text-sm font-semibold text-emerald-50">
-                      신청 진행 중
+                    <span className="rounded-full border border-emerald-600/70 bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
+                      접수 완료
                     </span>
                   )}
                 </div>

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -1,14 +1,16 @@
 import { Calendar, Calculator, FileSearch, TrendingDown, Upload } from "lucide-react";
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
-import { API_BASE } from "../../lib/api";
+import { API_BASE, getJson } from "../../lib/api";
 
-type StoredLoanApplication = {
-  applicationId: string;
-  productId: string;
+type LoanApplicationSummary = {
+  loanApplicationId: number;
+  productKey: string;
   productName: string;
-  status: string;
+  applicationStatus: string;
   appliedAt: string;
+  requiresCertificateSubmission: boolean;
+  certificateSubmitted: boolean;
 };
 
 type UploadStatus = "idle" | "selected" | "uploading" | "completed" | "failed";
@@ -24,9 +26,6 @@ type CertificateSubmissionResponse = {
   failureReason: string | null;
   submittedAt: string;
 };
-
-const LOAN_APPLICATIONS_KEY = "loanApplications";
-const DEFAULT_MEMBER_ID = "1";
 
 const loanInfo = {
   totalPrincipal: 20000000,
@@ -75,27 +74,10 @@ function formatAmount(value: number) {
   return `${value.toLocaleString("ko-KR")}원`;
 }
 
-function readLoanApplications() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    return JSON.parse(raw) as StoredLoanApplication[];
-  } catch {
-    return [];
-  }
-}
-
 export default function MyLoanManagement() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [simulationAmount, setSimulationAmount] = useState(1000000);
-  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+  const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -103,12 +85,24 @@ export default function MyLoanManagement() {
   const [certificateId, setCertificateId] = useState("");
 
   useEffect(() => {
-    const syncApplications = () => setApplications(readLoanApplications());
-    syncApplications();
-    window.addEventListener("storage", syncApplications);
+    const syncApplications = async () => {
+      if (localStorage.getItem("isLoggedIn") !== "true") {
+        setApplications([]);
+        return;
+      }
+
+      try {
+        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        setApplications(nextApplications);
+      } catch {
+        setApplications([]);
+      }
+    };
+    void syncApplications();
+    window.addEventListener("auth-change", syncApplications);
     window.addEventListener("loan-application-change", syncApplications);
     return () => {
-      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("auth-change", syncApplications);
       window.removeEventListener("loan-application-change", syncApplications);
     };
   }, []);
@@ -142,7 +136,7 @@ export default function MyLoanManagement() {
   );
 
   const selfDevelopmentApplication = useMemo(
-    () => applications.find((application) => application.productId === "youth-loan") ?? null,
+    () => applications.find((application) => application.productKey === "youth-loan") ?? null,
     [applications],
   );
 
@@ -174,8 +168,7 @@ export default function MyLoanManagement() {
     }
 
     const formData = new FormData();
-    formData.append("memberId", DEFAULT_MEMBER_ID);
-    formData.append("loanId", selfDevelopmentApplication.applicationId);
+    formData.append("loanId", String(selfDevelopmentApplication.loanApplicationId));
     formData.append("certificateId", certificateId);
     formData.append("file", selectedFile);
 
@@ -327,15 +320,15 @@ export default function MyLoanManagement() {
                 <div className="space-y-4">
                   {applications.map((application) => (
                     <div
-                      key={application.applicationId}
+                      key={application.loanApplicationId}
                       className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
                     >
                       <p className="text-sm text-slate-500">{application.productName}</p>
                       <p className="mt-2 text-lg font-semibold text-slate-900">
-                        {application.applicationId}
+                        {application.loanApplicationId}
                       </p>
                       <p className="mt-1 text-sm text-slate-600">
-                        상태 <span className="font-semibold text-sky-700">{application.status}</span>
+                        상태 <span className="font-semibold text-sky-700">{application.applicationStatus}</span>
                       </p>
                     </div>
                   ))}
@@ -345,7 +338,7 @@ export default function MyLoanManagement() {
                   <p className="text-sm text-slate-500">현재 신청한 대출 상품이 없습니다.</p>
                   <Link
                     to="/loan/products"
-                    className="mt-4 inline-block rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+                    className="mt-4 inline-block rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-[#5c7c97]"
                   >
                     대출 상품 보러가기
                   </Link>
@@ -441,13 +434,13 @@ export default function MyLoanManagement() {
                   <p className="mt-1">
                     신청 번호{" "}
                     <span className="font-semibold text-slate-900">
-                      {selfDevelopmentApplication.applicationId}
+                      {selfDevelopmentApplication.loanApplicationId}
                     </span>
                   </p>
                   <p className="mt-1">
                     상태{" "}
                     <span className="font-semibold text-sky-700">
-                      {selfDevelopmentApplication.status}
+                      {selfDevelopmentApplication.applicationStatus}
                     </span>
                   </p>
                 </div>
@@ -526,7 +519,7 @@ export default function MyLoanManagement() {
                         type="button"
                         onClick={handleUpload}
                         disabled={!selectedFile || uploadStatus === "uploading"}
-                        className="rounded-xl bg-slate-800 py-4 font-bold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-700 disabled:opacity-100 sm:flex-1"
+                        className="rounded-xl bg-[#8ea9bc] py-4 font-bold text-white shadow-md transition hover:bg-[#7d9aae] disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-700 disabled:opacity-100 sm:flex-1"
                       >
                         {uploadStatus === "uploading" ? "업로드 중..." : "업로드 시작"}
                       </button>
@@ -546,9 +539,6 @@ export default function MyLoanManagement() {
                       </div>
                     </div>
                     <p className="text-sm text-slate-500">{statusText[uploadStatus]}</p>
-                    <p className="mt-3 text-xs text-slate-400">
-                      현재 프론트 단에서는 로그인 회원의 숫자 ID를 받지 못해 기본 테스트 계정으로 요청합니다.
-                    </p>
                   </div>
 
                   <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-5">

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -1,12 +1,38 @@
-import { Calendar, Calculator, TrendingDown } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Calendar, Calculator, FileSearch, TrendingDown, Upload } from "lucide-react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
+import { API_BASE } from "../../lib/api";
+
+type StoredLoanApplication = {
+  applicationId: string;
+  productId: string;
+  productName: string;
+  status: string;
+  appliedAt: string;
+};
+
+type UploadStatus = "idle" | "selected" | "uploading" | "completed" | "failed";
+
+type CertificateSubmissionResponse = {
+  submissionId: number;
+  filename: string;
+  contentType: string;
+  extractedText: string;
+  lines: string[];
+  lineCount: number;
+  verificationStatus: string;
+  failureReason: string | null;
+  submittedAt: string;
+};
+
+const LOAN_APPLICATIONS_KEY = "loanApplications";
+const DEFAULT_MEMBER_ID = "1";
 
 const loanInfo = {
   totalPrincipal: 20000000,
   remainingPrincipal: 15000000,
   monthlyPayment: 450000,
   interestRate: 3.5,
-  startDate: "2024-03-25",
   maturityDate: "2028-03-24",
   nextPaymentDate: "2026-04-25",
   nextPaymentAmount: 450000,
@@ -22,197 +48,249 @@ const recentRepayments = [
   { date: "2026-01-25", amount: 450000, principal: 331000, interest: 119000 },
 ];
 
+const certificateGroups = [
+  { label: "사무/기초", options: [{ id: "1", label: "컴퓨터활용능력 1급" }, { id: "2", label: "컴퓨터활용능력 2급" }, { id: "3", label: "워드프로세서" }, { id: "4", label: "한국사능력검정시험" }] },
+  { label: "IT/데이터", options: [{ id: "5", label: "정보처리기사" }, { id: "6", label: "정보처리산업기사" }, { id: "7", label: "ADsP" }, { id: "8", label: "SQLD" }, { id: "9", label: "빅데이터분석기사" }] },
+  { label: "회계/금융", options: [{ id: "10", label: "전산회계 1급" }, { id: "11", label: "전산세무 2급" }, { id: "12", label: "투자자산운용사" }, { id: "13", label: "AFPK" }, { id: "14", label: "신용분석사" }] },
+  { label: "어학", options: [{ id: "18", label: "JLPT" }, { id: "19", label: "HSK" }] },
+  { label: "전문 자격", options: [{ id: "20", label: "공인중개사" }, { id: "21", label: "감정평가사" }, { id: "22", label: "세무사" }, { id: "23", label: "공인회계사" }, { id: "24", label: "변호사" }] },
+  { label: "기사", options: [{ id: "25", label: "전기기사" }, { id: "26", label: "산업안전기사" }, { id: "27", label: "건축기사" }, { id: "28", label: "토목기사" }, { id: "29", label: "기계기사" }] },
+];
+
+const ocrSteps = ["자격증 선택", "파일 업로드", "OCR 추출", "정보 검증"];
+
+const NO_TEXT_DETECTED_MESSAGE =
+  "문서에서 자격증 정보를 확인하지 못했습니다. 자격증 전체가 잘 보이는 이미지 또는 PDF를 업로드해 주세요.";
+
+const failureReasonMessages: Record<string, string> = {
+  CERTIFICATE_NAME_MISMATCH: "선택한 자격증 종류와 업로드한 문서가 일치하지 않습니다.",
+  ISSUER_NAME_MISMATCH: "발급기관 정보를 확인할 수 없습니다. 문서 원본을 다시 확인해 주세요.",
+  NAME_MISMATCH: "회원 정보의 이름과 문서의 이름이 일치하지 않습니다.",
+  PASS_KEYWORD_NOT_FOUND: "합격 또는 취득을 확인할 수 있는 문구를 찾지 못했습니다.",
+  INVALID_DOCUMENT_TYPE: "자격증 증빙용 문서로 확인되지 않습니다.",
+  OCR_TEXT_NOT_DETECTED: NO_TEXT_DETECTED_MESSAGE,
+};
+
 function formatAmount(value: number) {
   return `${value.toLocaleString("ko-KR")}원`;
 }
 
+function readLoanApplications() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(LOAN_APPLICATIONS_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(raw) as StoredLoanApplication[];
+  } catch {
+    return [];
+  }
+}
+
 export default function MyLoanManagement() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [simulationAmount, setSimulationAmount] = useState(1000000);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [ocrResult, setOcrResult] = useState<CertificateSubmissionResponse | null>(null);
+  const [certificateId, setCertificateId] = useState("");
+
+  useEffect(() => {
+    const syncApplications = () => setApplications(readLoanApplications());
+    syncApplications();
+    window.addEventListener("storage", syncApplications);
+    window.addEventListener("loan-application-change", syncApplications);
+    return () => {
+      window.removeEventListener("storage", syncApplications);
+      window.removeEventListener("loan-application-change", syncApplications);
+    };
+  }, []);
+
   const repaidPrincipal = loanInfo.totalPrincipal - loanInfo.remainingPrincipal;
   const repaymentProgress = (repaidPrincipal / loanInfo.totalPrincipal) * 100;
+  const averagePrincipalPayment = useMemo(
+    () =>
+      Math.round(
+        recentRepayments.reduce((sum, item) => sum + item.principal, 0) /
+          recentRepayments.length,
+      ),
+    [],
+  );
+  const estimatedSavedMonths =
+    averagePrincipalPayment > 0 ? Math.floor(simulationAmount / averagePrincipalPayment) : 0;
+  const estimatedInterestSavings = Math.round(
+    simulationAmount *
+      (loanInfo.interestRate / 100) *
+      (Math.max(estimatedSavedMonths, 1) / 12) *
+      0.55,
+  );
+  const remainingAfterSimulation = Math.max(loanInfo.remainingPrincipal - simulationAmount, 0);
 
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const nextPaymentDate = new Date(`${loanInfo.nextPaymentDate}T00:00:00`);
   const daysUntilNextPayment = Math.max(
     Math.ceil((nextPaymentDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
     0,
   );
 
-  const averagePrincipalPayment = useMemo(() => {
-    return Math.round(
-      recentRepayments.reduce((sum, item) => sum + item.principal, 0) / recentRepayments.length,
-    );
-  }, []);
-
-  const remainingAfterSimulation = Math.max(loanInfo.remainingPrincipal - simulationAmount, 0);
-  const estimatedSavedMonths =
-    averagePrincipalPayment > 0 ? Math.floor(simulationAmount / averagePrincipalPayment) : 0;
-  const estimatedInterestSavings = Math.round(
-    simulationAmount * (loanInfo.interestRate / 100) * (Math.max(estimatedSavedMonths, 1) / 12) * 0.55,
+  const selfDevelopmentApplication = useMemo(
+    () => applications.find((application) => application.productId === "youth-loan") ?? null,
+    [applications],
   );
 
-  const calculateSimulationDate = () => {
-    if (remainingAfterSimulation <= 0) {
-      return "즉시 상환 가능";
+  const statusText: Record<UploadStatus, string> = {
+    idle: "자기계발 대출 신청 후 자격증 파일을 제출할 수 있습니다.",
+    selected: `선택한 파일: ${selectedFile?.name ?? ""}`,
+    uploading: "OCR 요청을 전송하고 있습니다.",
+    completed: "OCR 업로드가 완료되었습니다. 인증 결과를 확인해 주세요.",
+    failed: uploadError ?? "업로드 중 오류가 발생했습니다.",
+  };
+
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    setUploadStatus(file ? "selected" : "idle");
+    setUploadError(null);
+    setOcrResult(null);
+  };
+
+  const handleUpload = async () => {
+    if (!selfDevelopmentApplication || !selectedFile) {
+      return;
     }
 
-    const completionDate = new Date(`${loanInfo.maturityDate}T00:00:00`);
-    completionDate.setMonth(completionDate.getMonth() - estimatedSavedMonths);
-    return completionDate.toLocaleDateString("ko-KR");
+    if (!certificateId) {
+      setUploadStatus("failed");
+      setUploadError("자격증 종류를 선택해 주세요.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("memberId", DEFAULT_MEMBER_ID);
+    formData.append("loanId", selfDevelopmentApplication.applicationId);
+    formData.append("certificateId", certificateId);
+    formData.append("file", selectedFile);
+
+    setUploadStatus("uploading");
+    setUploadError(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/api/certificates/submissions`, {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorBody = (await response.json().catch(() => null)) as { message?: string } | null;
+        const message = errorBody?.message ?? "자격증 업로드에 실패했습니다.";
+        throw new Error(
+          message.includes("No text detected from image")
+            ? NO_TEXT_DETECTED_MESSAGE
+            : message,
+        );
+      }
+
+      const result = (await response.json()) as CertificateSubmissionResponse;
+      setOcrResult(result);
+
+      if (result.verificationStatus === "VERIFICATION_FAILED" && result.failureReason) {
+        setUploadStatus("failed");
+        setUploadError(
+          failureReasonMessages[result.failureReason] ??
+            "자격증 인증에 실패했습니다. 업로드한 문서를 다시 확인해 주세요.",
+        );
+        return;
+      }
+
+      setUploadStatus("completed");
+    } catch (error) {
+      setUploadStatus("failed");
+      setUploadError(
+        error instanceof Error ? error.message : "예기치 못한 오류가 발생했습니다.",
+      );
+      setOcrResult(null);
+    }
   };
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-10 md:px-6">
       <div className="overflow-hidden rounded-[32px] border border-slate-200/80 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
         <div className="border-b border-slate-100 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.14),_transparent_38%),linear-gradient(135deg,_#f8fbff_0%,_#ffffff_52%,_#f8fafc_100%)] px-6 py-6 md:px-8">
-          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-blue-500">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-sky-600">
             Loan Management
           </p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">대출 관리</h1>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">내 대출 관리</h1>
           <p className="mt-2 text-sm text-slate-500">
-            대출 원금, 상환 진행률, 최근 상환 내역을 기준으로 현재 상태를 관리하는 화면입니다.
+            상환 현황, 조기 상환 시뮬레이션, 신청 중인 상품 상태를 한 곳에서 확인할 수 있습니다.
           </p>
-
-          <div className="mt-6 grid gap-4 md:grid-cols-4">
-            <div className="rounded-3xl border border-sky-100 bg-[linear-gradient(135deg,_rgba(219,234,254,0.95)_0%,_rgba(239,246,255,0.98)_48%,_rgba(248,250,252,1)_100%)] px-5 py-5 text-slate-900 shadow-[0_20px_45px_rgba(148,163,184,0.18)]">
-              <p className="text-xs tracking-[0.12em] text-sky-700/70">대출 잔액</p>
-              <p className="mt-3 text-3xl font-semibold">{formatAmount(loanInfo.remainingPrincipal)}</p>
-              <p className="mt-2 text-sm text-slate-500">현재 남아 있는 원금 기준입니다.</p>
-            </div>
-
-            <div className="rounded-3xl border border-blue-100 bg-blue-50/70 px-5 py-5">
-              <p className="text-sm font-medium text-slate-500">차입금</p>
-              <p className="mt-4 text-2xl font-bold text-slate-900">
-                {formatAmount(loanInfo.totalPrincipal)}
-              </p>
-              <p className="mt-2 text-sm text-slate-500">최초 실행한 대출 원금입니다.</p>
-            </div>
-
-            <div className="rounded-3xl border border-emerald-100 bg-emerald-50/80 px-5 py-5">
-              <p className="text-sm font-medium text-slate-500">상환액</p>
-              <p className="mt-4 text-2xl font-bold text-slate-900">
-                {formatAmount(repaidPrincipal)}
-              </p>
-              <p className="mt-2 text-sm text-slate-500">누적 상환한 원금 기준 금액입니다.</p>
-            </div>
-
-            <div className="rounded-3xl border border-indigo-100 bg-indigo-50/80 px-5 py-5">
-              <p className="text-sm font-medium text-slate-500">금리</p>
-              <p className="mt-4 text-2xl font-bold text-slate-900">
-                연 {loanInfo.interestRate.toFixed(1)}%
-              </p>
-              <p className="mt-2 text-sm text-slate-500">현재 적용 중인 기준 금리입니다.</p>
-            </div>
-          </div>
         </div>
 
         <div className="space-y-8 px-6 py-8 md:px-8 lg:px-10">
-          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
-            <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-slate-900">대출 현황</h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  원금 상환 진행률과 월 납입 계획을 함께 보여줍니다.
-                </p>
-              </div>
-              <p className="text-sm font-medium text-slate-500">
-                만기일<span className="ml-1 text-slate-900">{loanInfo.maturityDate}</span>
+          <section className="grid gap-4 md:grid-cols-4">
+            <div className="rounded-3xl border border-sky-100 bg-sky-50/80 px-5 py-5">
+              <p className="text-sm text-slate-500">잔여 원금</p>
+              <p className="mt-3 text-3xl font-semibold text-slate-900">
+                {formatAmount(loanInfo.remainingPrincipal)}
               </p>
             </div>
-
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
-              <div className="rounded-3xl border border-slate-100 bg-slate-50/80 p-5">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-slate-500">원금 상환 진행률</p>
-                    <p className="mt-2 text-3xl font-bold text-slate-900">
-                      {repaymentProgress.toFixed(1)}%
-                    </p>
-                  </div>
-                  <div className="rounded-2xl bg-blue-50 p-3 text-blue-600">
-                    <TrendingDown className="h-5 w-5" />
-                  </div>
-                </div>
-
-                <div className="mt-6">
-                  <div className="mb-2 flex items-center justify-between text-sm text-slate-500">
-                    <span>누적 상환 원금</span>
-                    <span className="font-semibold text-slate-900">
-                      {formatAmount(repaidPrincipal)}
-                    </span>
-                  </div>
-                  <div className="h-3 overflow-hidden rounded-full bg-slate-200">
-                    <div
-                      className="h-full rounded-full bg-[linear-gradient(90deg,_#60a5fa_0%,_#2563eb_100%)]"
-                      style={{ width: `${repaymentProgress}%` }}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
-                <div className="flex items-center gap-4 rounded-3xl border border-slate-100 bg-slate-50/80 p-5">
-                  <div className="rounded-2xl bg-blue-50 p-3 text-blue-600">
-                    <TrendingDown className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-slate-500">월 납입 예정액</p>
-                    <p className="mt-1 text-xl font-semibold text-slate-900">
-                      {formatAmount(loanInfo.monthlyPayment)}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-4 rounded-3xl border border-slate-100 bg-slate-50/80 p-5">
-                  <div className="rounded-2xl bg-indigo-50 p-3 text-indigo-600">
-                    <Calendar className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-slate-500">예정 만기일</p>
-                    <p className="mt-1 text-xl font-semibold text-slate-900">
-                      {loanInfo.maturityDate}
-                    </p>
-                  </div>
-                </div>
-              </div>
+            <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
+              <p className="text-sm text-slate-500">총 원금</p>
+              <p className="mt-3 text-2xl font-bold text-slate-900">
+                {formatAmount(loanInfo.totalPrincipal)}
+              </p>
+            </div>
+            <div className="rounded-3xl border border-emerald-100 bg-emerald-50/80 px-5 py-5">
+              <p className="text-sm text-slate-500">누적 상환 원금</p>
+              <p className="mt-3 text-2xl font-bold text-slate-900">
+                {formatAmount(repaidPrincipal)}
+              </p>
+            </div>
+            <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
+              <p className="text-sm text-slate-500">금리</p>
+              <p className="mt-3 text-2xl font-bold text-slate-900">
+                연 {loanInfo.interestRate.toFixed(1)}%
+              </p>
             </div>
           </section>
 
-          <section className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(340px,0.82fr)] lg:items-stretch">
+          <section className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(340px,0.82fr)]">
             <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
               <div className="mb-6 flex items-center gap-3">
-                <div className="rounded-2xl bg-blue-50 p-3 text-blue-600">
+                <div className="rounded-2xl bg-sky-50 p-3 text-sky-600">
                   <Calculator className="h-5 w-5" />
                 </div>
                 <div>
                   <h2 className="text-xl font-bold text-slate-900">조기 상환 시뮬레이션</h2>
                   <p className="mt-1 text-sm text-slate-500">
-                    추가 상환 원금이 들어간다고 가정하고 잔액과 예상 종료 시점을 계산합니다.
+                    추가 상환 원금을 입력하면 예상 종료 시점과 절감 이자를 계산합니다.
                   </p>
                 </div>
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium text-slate-600">추가 상환 원금</label>
-                <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                  <input
-                    type="range"
-                    min="0"
-                    max={loanInfo.remainingPrincipal}
-                    step="100000"
-                    value={simulationAmount}
-                    onChange={(event) => setSimulationAmount(Number(event.target.value))}
-                    className="flex-1 accent-blue-600"
-                  />
-                  <input
-                    type="number"
-                    value={simulationAmount}
-                    onChange={(event) => setSimulationAmount(Number(event.target.value))}
-                    className="h-12 w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 md:w-44"
-                  />
-                </div>
-              </div>
+              <input
+                type="range"
+                min="0"
+                max={loanInfo.remainingPrincipal}
+                step="100000"
+                value={simulationAmount}
+                onChange={(event) => setSimulationAmount(Number(event.target.value))}
+                className="w-full accent-sky-600"
+              />
+              <input
+                type="number"
+                value={simulationAmount}
+                onChange={(event) => setSimulationAmount(Number(event.target.value))}
+                className="mt-4 h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-sky-400 focus:ring-4 focus:ring-sky-100"
+              />
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-5">
@@ -221,122 +299,86 @@ export default function MyLoanManagement() {
                     {formatAmount(remainingAfterSimulation)}
                   </p>
                 </div>
-
-                <div className="rounded-2xl border border-indigo-100 bg-indigo-50/80 px-5 py-5">
-                  <p className="text-sm text-slate-500">예상 종료 시점</p>
-                  <p className="mt-2 text-2xl font-bold text-slate-900">
-                    {calculateSimulationDate()}
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-4 grid gap-4 md:grid-cols-2">
-                <div className="rounded-2xl border border-blue-100 bg-blue-50/80 px-5 py-5">
-                  <p className="text-sm text-slate-500">예상 절감 이자</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
-                    {formatAmount(estimatedInterestSavings)}
-                  </p>
-                </div>
-
-                <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-5">
+                <div className="rounded-2xl border border-sky-100 bg-sky-50/60 px-5 py-5">
                   <p className="text-sm text-slate-500">예상 단축 기간</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                  <p className="mt-2 text-2xl font-bold text-slate-900">
                     약 {estimatedSavedMonths}개월
                   </p>
                 </div>
               </div>
 
-              <button className="mt-6 w-full rounded-2xl bg-blue-600 py-4 font-semibold text-white transition hover:bg-blue-700">
-                추가 상환하기
-              </button>
-
-              <p className="mt-4 text-center text-sm text-slate-500">
-                실제 조기 상환 수수료, 상환 방식, 이자 계산 규칙에 따라 값은 달라질 수 있습니다.
-              </p>
+              <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50/60 px-5 py-5">
+                <p className="text-sm text-slate-500">예상 절감 이자</p>
+                <p className="mt-2 text-xl font-semibold text-slate-900">
+                  {formatAmount(estimatedInterestSavings)}
+                </p>
+              </div>
             </div>
 
             <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
               <div className="mb-5">
-                <h2 className="text-xl font-bold text-slate-900">관리 정보</h2>
+                <h2 className="text-xl font-bold text-slate-900">내 대출 신청</h2>
                 <p className="mt-1 text-sm text-slate-500">
-                  백엔드 연동 시 즉시 확인해야 할 핵심 상태를 보여주는 영역입니다.
+                  신청한 상품이 있으면 진행 상태를, 없으면 신청 가능한 상품을 안내합니다.
                 </p>
               </div>
 
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="flex min-h-[148px] flex-col rounded-2xl border border-blue-100 bg-blue-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">다음 납입 예정일</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-900">
-                    {loanInfo.nextPaymentDate} / {formatAmount(loanInfo.nextPaymentAmount)}
-                  </p>
-                  <p className="mt-auto pt-3 text-sm leading-6 text-slate-600">
-                    오늘 기준 {daysUntilNextPayment}일 남았습니다.
-                  </p>
+              {applications.length > 0 ? (
+                <div className="space-y-4">
+                  {applications.map((application) => (
+                    <div
+                      key={application.applicationId}
+                      className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
+                    >
+                      <p className="text-sm text-slate-500">{application.productName}</p>
+                      <p className="mt-2 text-lg font-semibold text-slate-900">
+                        {application.applicationId}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        상태 <span className="font-semibold text-sky-700">{application.status}</span>
+                      </p>
+                    </div>
+                  ))}
                 </div>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-5 py-6">
+                  <p className="text-sm text-slate-500">현재 신청한 대출 상품이 없습니다.</p>
+                  <Link
+                    to="/loan/products"
+                    className="mt-4 inline-block rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+                  >
+                    대출 상품 보러가기
+                  </Link>
+                </div>
+              )}
 
-                <div className="flex min-h-[148px] flex-col rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">상환 진도</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-900">
-                    총 원금의 {repaymentProgress.toFixed(1)}%를 상환했습니다.
-                  </p>
-                </div>
-
-                <div className="flex min-h-[148px] flex-col rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">추가 상환 효과</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-900">
-                    약 {estimatedSavedMonths}개월 단축 예상
-                  </p>
-                </div>
-
-                <div className="flex min-h-[148px] flex-col rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">상환 방식 / 출금 계좌</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-900">
-                    {loanInfo.repaymentType}
-                  </p>
-                  <p className="mt-1 text-sm text-slate-600">
-                    자동이체 계좌 {loanInfo.autoDebitAccount}
-                  </p>
-                </div>
-
-                <div className="flex min-h-[148px] flex-col rounded-2xl border border-amber-100 bg-amber-50/80 px-4 py-4 sm:col-span-2">
-                  <p className="text-sm text-slate-500">이번 달 체크 사항</p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    다음 납입일 전에 출금 계좌 잔액을 확인하고, 여유 자금이 있다면 조기 상환으로 남은 이자 부담을 줄일 수 있습니다.
-                  </p>
-                </div>
+              <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50/60 px-4 py-4">
+                <p className="text-sm text-slate-500">다음 납입 예정일</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">
+                  {loanInfo.nextPaymentDate} / {formatAmount(loanInfo.nextPaymentAmount)}
+                </p>
+                <p className="mt-2 text-sm text-slate-600">
+                  오늘 기준 {daysUntilNextPayment}일 남았습니다.
+                </p>
               </div>
             </div>
           </section>
 
           <section className="grid gap-5 lg:grid-cols-[minmax(0,1.1fr)_minmax(300px,0.9fr)]">
             <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
-              <div className="mb-5">
-                <h2 className="text-xl font-bold text-slate-900">최근 상환 내역</h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  최근 납입 금액과 원금, 이자 구성 비율을 확인할 수 있습니다.
-                </p>
-              </div>
-
-              <div className="space-y-3">
+              <h2 className="text-xl font-bold text-slate-900">최근 상환 내역</h2>
+              <div className="mt-5 space-y-3">
                 {recentRepayments.map((repayment) => (
                   <div
                     key={repayment.date}
-                    className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 md:flex-row md:items-center md:justify-between ${
-                      repayment === recentRepayments[0]
-                        ? "border-blue-100 bg-blue-50/70"
-                        : "border-slate-100 bg-slate-50/80"
-                    }`}
+                    className="flex flex-col gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4 md:flex-row md:items-center md:justify-between"
                   >
                     <div>
                       <p className="text-sm text-slate-500">{repayment.date}</p>
                       <p className="mt-1 text-lg font-semibold text-slate-900">
                         {formatAmount(repayment.amount)}
                       </p>
-                      {repayment === recentRepayments[0] && (
-                        <p className="mt-1 text-xs font-medium text-blue-600">가장 최근 상환</p>
-                      )}
                     </div>
-
                     <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-2 md:gap-8">
                       <div>
                         <p className="text-slate-500">원금</p>
@@ -357,44 +399,216 @@ export default function MyLoanManagement() {
             </div>
 
             <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
-              <div className="mb-5">
-                <h2 className="text-xl font-bold text-slate-900">이자 정보</h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  지금까지 낸 이자와 앞으로 예상되는 부담을 함께 봅니다.
-                </p>
-              </div>
-
-              <div className="space-y-4">
+              <h2 className="text-xl font-bold text-slate-900">이자 정보</h2>
+              <div className="mt-5 space-y-4">
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">누적 상환 이자</p>
+                  <p className="text-sm text-slate-500">누적 납입 이자</p>
                   <p className="mt-2 text-2xl font-bold text-slate-900">
                     {formatAmount(loanInfo.cumulativeInterest)}
                   </p>
                 </div>
-
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">남은 예상 이자</p>
+                  <p className="text-sm text-slate-500">잔여 예상 이자</p>
                   <p className="mt-2 text-2xl font-bold text-slate-900">
                     {formatAmount(loanInfo.estimatedRemainingInterest)}
-                  </p>
-                </div>
-
-                <div className="rounded-2xl border border-indigo-100 bg-indigo-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">현재 금리 기준 메모</p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    현재 금리와 평균 원금 상환 속도를 기준으로 보면 조기 상환 시 이자 절감 효과가 분명한 구간입니다.
-                  </p>
-                </div>
-
-                <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
-                  <p className="text-sm text-slate-500">한 줄 해석</p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    앞으로 낼 예상 이자가 아직 큰 편이라, 여유 자금이 있을 때 일부 원금을 먼저 줄이는 전략이 유리합니다.
                   </p>
                 </div>
               </div>
             </div>
           </section>
+
+          {selfDevelopmentApplication && (
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.24em] text-sky-600">
+                    Self Development
+                  </p>
+                  <h2 className="mt-2 text-2xl font-bold text-slate-900">
+                    자기계발 대출 OCR 제출
+                  </h2>
+                  <p className="mt-2 text-sm text-slate-500">
+                    자기계발 대출 신청자에게만 보이는 제출 영역입니다.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-sky-100 bg-sky-50/60 px-4 py-4 text-sm text-slate-600">
+                  <p>
+                    신청 상품{" "}
+                    <span className="font-semibold text-slate-900">
+                      {selfDevelopmentApplication.productName}
+                    </span>
+                  </p>
+                  <p className="mt-1">
+                    신청 번호{" "}
+                    <span className="font-semibold text-slate-900">
+                      {selfDevelopmentApplication.applicationId}
+                    </span>
+                  </p>
+                  <p className="mt-1">
+                    상태{" "}
+                    <span className="font-semibold text-sky-700">
+                      {selfDevelopmentApplication.status}
+                    </span>
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-6 lg:grid-cols-[minmax(0,1.18fr)_minmax(320px,0.82fr)]">
+                <div>
+                  <div className="mb-4 rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+                    <div className="mb-3 flex items-center justify-between">
+                      <p className="font-medium text-slate-700">지원 자격증 안내</p>
+                      <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
+                        총 26종
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs text-slate-600">
+                      {certificateGroups.map((group) => (
+                        <span
+                          key={group.label}
+                          className="rounded-full border border-slate-200 bg-white px-3 py-1"
+                        >
+                          {group.label}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="mb-4 rounded-xl border border-slate-200 bg-white px-4 py-2 shadow-sm">
+                    <p className="mb-1 text-xs font-medium text-slate-500">자격증 종류</p>
+                    <select
+                      value={certificateId}
+                      onChange={(event) => setCertificateId(event.target.value)}
+                      className="w-full bg-transparent py-1 text-sm text-slate-900 outline-none"
+                    >
+                      <option value="">자격증 종류 선택</option>
+                      {certificateGroups.map((group) => (
+                        <optgroup key={group.label} label={group.label}>
+                          {group.options.map((certificate) => (
+                            <option key={certificate.id} value={certificate.id}>
+                              {certificate.label}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="rounded-3xl border-2 border-dashed border-sky-200 bg-slate-50 p-8">
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".jpg,.jpeg,.png,.pdf"
+                      className="hidden"
+                      onChange={handleFileSelect}
+                    />
+                    <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-sky-100">
+                      <Upload className="h-7 w-7 text-sky-700" />
+                    </div>
+                    <h3 className="mb-2 text-xl font-bold text-slate-900">자격증 파일 업로드</h3>
+                    <p className="mb-6 text-slate-500">
+                      JPG, PNG, PDF 형식의 자격증 파일을 업로드해 주세요.
+                    </p>
+                    <div className="mb-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+                      <p className="text-sm font-medium text-slate-700">
+                        {selectedFile ? selectedFile.name : "선택된 파일이 없습니다."}
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-4 sm:flex-row">
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="rounded-xl bg-sky-100 py-4 font-bold text-slate-900 transition hover:bg-sky-200 sm:flex-1"
+                      >
+                        파일 선택
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleUpload}
+                        disabled={!selectedFile || uploadStatus === "uploading"}
+                        className="rounded-xl bg-slate-800 py-4 font-bold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-700 disabled:opacity-100 sm:flex-1"
+                      >
+                        {uploadStatus === "uploading" ? "업로드 중..." : "업로드 시작"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-5">
+                    <div className="mb-3 flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-100">
+                        <FileSearch className="h-5 w-5 text-sky-700" />
+                      </div>
+                      <div>
+                        <p className="text-sm text-slate-500">OCR 진행 상태</p>
+                        <h3 className="text-lg font-bold text-slate-900">업로드 현황</h3>
+                      </div>
+                    </div>
+                    <p className="text-sm text-slate-500">{statusText[uploadStatus]}</p>
+                    <p className="mt-3 text-xs text-slate-400">
+                      현재 프론트 단에서는 로그인 회원의 숫자 ID를 받지 못해 기본 테스트 계정으로 요청합니다.
+                    </p>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-5">
+                    <p className="mb-3 text-sm text-slate-500">인증 단계</p>
+                    <div className="space-y-3">
+                      {ocrSteps.map((step, index) => (
+                        <div key={step} className="flex items-center gap-3">
+                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-sky-100 text-sm font-semibold text-sky-700">
+                            {index + 1}
+                          </div>
+                          <p className="text-sm font-medium text-slate-700">{step}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {uploadStatus === "failed" && uploadError && (
+                    <div className="rounded-2xl border border-red-200 bg-red-50 p-5">
+                      <p className="mb-2 text-sm text-red-700">업로드 오류</p>
+                      <p className="text-sm text-red-900">{uploadError}</p>
+                    </div>
+                  )}
+
+                  {ocrResult && (
+                    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                      <p className="mb-2 text-sm text-slate-500">인증 결과</p>
+                      <h3 className="mb-4 text-lg font-bold text-slate-900">
+                        {ocrResult.verificationStatus === "VERIFIED"
+                          ? "자격증 인증 완료"
+                          : "자격증 인증 확인 필요"}
+                      </h3>
+                      <div className="space-y-3 text-sm text-slate-600">
+                        <p>
+                          인증 상태{" "}
+                          <span className="font-semibold text-slate-900">
+                            {ocrResult.verificationStatus}
+                          </span>
+                        </p>
+                        <p>
+                          추출 라인 수{" "}
+                          <span className="font-semibold text-slate-900">
+                            {ocrResult.lineCount}
+                          </span>
+                        </p>
+                        {ocrResult.failureReason && (
+                          <p>
+                            실패 사유{" "}
+                            <span className="font-semibold text-slate-900">
+                              {failureReasonMessages[ocrResult.failureReason] ??
+                                ocrResult.failureReason}
+                            </span>
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -70,6 +70,25 @@ const failureReasonMessages: Record<string, string> = {
   OCR_TEXT_NOT_DETECTED: NO_TEXT_DETECTED_MESSAGE,
 };
 
+function getApplicationStatusLabel(application: LoanApplicationSummary) {
+  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
+    return "서류 제출 완료";
+  }
+
+  switch (application.applicationStatus) {
+    case "DOCUMENT_REQUIRED":
+      return "서류 제출 필요";
+    case "UNDER_REVIEW":
+      return "심사 진행 중";
+    case "APPROVED":
+      return "이용 중";
+    case "REJECTED":
+      return "심사 반려";
+    default:
+      return application.applicationStatus;
+  }
+}
+
 function formatAmount(value: number) {
   return `${value.toLocaleString("ko-KR")}원`;
 }
@@ -139,6 +158,8 @@ export default function MyLoanManagement() {
     () => applications.find((application) => application.productKey === "youth-loan") ?? null,
     [applications],
   );
+  const canSubmitCertificate =
+    !!selfDevelopmentApplication && !selfDevelopmentApplication.certificateSubmitted;
 
   const statusText: Record<UploadStatus, string> = {
     idle: "자기계발 대출 신청 후 자격증 파일을 제출할 수 있습니다.",
@@ -205,6 +226,7 @@ export default function MyLoanManagement() {
       }
 
       setUploadStatus("completed");
+      window.dispatchEvent(new Event("loan-application-change"));
     } catch (error) {
       setUploadStatus("failed");
       setUploadError(
@@ -324,11 +346,8 @@ export default function MyLoanManagement() {
                       className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
                     >
                       <p className="text-sm text-slate-500">{application.productName}</p>
-                      <p className="mt-2 text-lg font-semibold text-slate-900">
-                        {application.loanApplicationId}
-                      </p>
                       <p className="mt-1 text-sm text-slate-600">
-                        상태 <span className="font-semibold text-sky-700">{application.applicationStatus}</span>
+                        상태 <span className="font-semibold text-sky-700">{getApplicationStatusLabel(application)}</span>
                       </p>
                     </div>
                   ))}
@@ -432,15 +451,9 @@ export default function MyLoanManagement() {
                     </span>
                   </p>
                   <p className="mt-1">
-                    신청 번호{" "}
-                    <span className="font-semibold text-slate-900">
-                      {selfDevelopmentApplication.loanApplicationId}
-                    </span>
-                  </p>
-                  <p className="mt-1">
                     상태{" "}
                     <span className="font-semibold text-sky-700">
-                      {selfDevelopmentApplication.applicationStatus}
+                      {getApplicationStatusLabel(selfDevelopmentApplication)}
                     </span>
                   </p>
                 </div>
@@ -466,6 +479,15 @@ export default function MyLoanManagement() {
                       ))}
                     </div>
                   </div>
+
+                  {!canSubmitCertificate && (
+                    <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50/70 px-4 py-4">
+                      <p className="text-sm font-semibold text-emerald-700">서류 제출 완료</p>
+                      <p className="mt-2 text-sm text-slate-600">
+                        자기계발 대출 신청 건에 필요한 서류 제출이 완료되었습니다. 인증 결과와 진행 상태를 확인해 주세요.
+                      </p>
+                    </div>
+                  )}
 
                   <div className="mb-4 rounded-xl border border-slate-200 bg-white px-4 py-2 shadow-sm">
                     <p className="mb-1 text-xs font-medium text-slate-500">자격증 종류</p>
@@ -511,14 +533,15 @@ export default function MyLoanManagement() {
                       <button
                         type="button"
                         onClick={() => fileInputRef.current?.click()}
-                        className="rounded-xl bg-sky-100 py-4 font-bold text-slate-900 transition hover:bg-sky-200 sm:flex-1"
+                        disabled={!canSubmitCertificate}
+                        className="rounded-xl bg-sky-100 py-4 font-bold text-slate-900 transition hover:bg-sky-200 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500 sm:flex-1"
                       >
                         파일 선택
                       </button>
                       <button
                         type="button"
                         onClick={handleUpload}
-                        disabled={!selectedFile || uploadStatus === "uploading"}
+                        disabled={!canSubmitCertificate || !selectedFile || uploadStatus === "uploading"}
                         className="rounded-xl bg-[#8ea9bc] py-4 font-bold text-white shadow-md transition hover:bg-[#7d9aae] disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-700 disabled:opacity-100 sm:flex-1"
                       >
                         {uploadStatus === "uploading" ? "업로드 중..." : "업로드 시작"}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -7,6 +7,7 @@ import MyAccount from "./pages/account/MyAccount";
 import DdokgaeAccount from "./pages/account/DdokgaeAccount";
 import LoanProducts from "./pages/loan/LoanProducts";
 import LoanDetail from "./pages/loan/LoanDetail";
+import LoanApply from "./pages/loan/LoanApply";
 import MyLoanManagement from "./pages/loan/MyLoanManagement";
 import MyCreditScore from "./pages/loan/MyCreditScore";
 import DdokgaeCard from "./pages/card/DdokgaeCard";
@@ -27,6 +28,7 @@ export const router = createBrowserRouter([
       { path: "account/ddokgae", Component: DdokgaeAccount },
       { path: "loan/products", Component: LoanProducts },
       { path: "loan/products/:productId", Component: LoanDetail },
+      { path: "loan/products/:productId/apply", Component: LoanApply },
       { path: "loan/management", Component: MyLoanManagement },
       { path: "loan/credit-score", Component: MyCreditScore },
       { path: "card/ddokgae", Component: DdokgaeCard },


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #30 

---

### 📝 작업 내용
- 대출 상품 목록/상세에 `자기계발 대출` 상품을 추가하고 `소비분석 대출`과 함께 메인 상품으로 노출했습니다.
- 상품 상세에서 별도 대출 신청 페이지로 이동해 신청 정보 입력 및 약관 동의 후 신청할 수 있도록 흐름을 분리했습니다.
- 신청 완료 시 상품 목록과 상세에서 상태를 반영하고, 이미 신청한 상품은 `내 대출 관리`로 이동할 수 있도록 정리했습니다.
- 기존 마이페이지의 자격증 OCR 업로드 기능을 `내 대출 관리` 페이지 하단으로 이동했습니다.
- 자기계발 대출 신청 건이 있는 경우에만 OCR 제출 영역이 보이도록 구성했습니다.
- OCR 업로드 상태, 실패 사유, 인증 결과 문구를 화면에서 확인할 수 있도록 정리했습니다.
- 초기 임시 `localStorage` 상태 관리를 제거하고, 백엔드 신청 상태 API 기준으로 화면이 동작하도록 연동했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 대출 신청 페이지 및 신청 프로세스 추가
  * 대출 관리에서 인증서 OCR 제출 및 검증 기능 추가
  * 상품별 신청 경로(신규 라우트) 추가

* **개선 사항**
  * 대출 상품 목록·상세 UI와 카드 레이아웃 개선
  * 신청 현황 연동 및 상태 표시·네비게이션 개선
  * 회원정보 페이지 구성·퀵메뉴 문구 및 아이콘 정리, 주요 CTA 링크 방식 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->