### PR TITLE
Feat: 내 대출 관리 페이지 실데이터 연동

### DIFF
--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -107,8 +107,18 @@ function formatAmount(value: number) {
   return `${value.toLocaleString("ko-KR")}원`;
 }
 
+function normalizeSimulationAmount(value: number, max: number) {
+  if (!Number.isFinite(value) || max <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(value, 0), max);
+}
+
 export default function MyLoanManagement() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const applicationsRequestIdRef = useRef(0);
+  const loanManagementRequestIdRef = useRef(0);
   const [simulationAmount, setSimulationAmount] = useState(1000000);
   const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
   const [summary, setSummary] = useState<MyLoanSummary | null>(null);
@@ -124,6 +134,7 @@ export default function MyLoanManagement() {
 
   useEffect(() => {
     const syncApplications = async () => {
+      const requestId = ++applicationsRequestIdRef.current;
       if (localStorage.getItem("isLoggedIn") !== "true") {
         setApplications([]);
         return;
@@ -131,22 +142,32 @@ export default function MyLoanManagement() {
 
       try {
         const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
-        setApplications(nextApplications);
+        if (requestId === applicationsRequestIdRef.current) {
+          setApplications(nextApplications);
+        }
       } catch {
-        setApplications([]);
+        if (requestId === applicationsRequestIdRef.current) {
+          setApplications([]);
+        }
       }
+    };
+    const handleStorageChange = () => {
+      void syncApplications();
     };
     void syncApplications();
     window.addEventListener("auth-change", syncApplications);
     window.addEventListener("loan-application-change", syncApplications);
+    window.addEventListener("storage", handleStorageChange);
     return () => {
       window.removeEventListener("auth-change", syncApplications);
       window.removeEventListener("loan-application-change", syncApplications);
+      window.removeEventListener("storage", handleStorageChange);
     };
   }, []);
 
   useEffect(() => {
     const syncLoanManagement = async () => {
+      const requestId = ++loanManagementRequestIdRef.current;
       if (localStorage.getItem("isLoggedIn") !== "true") {
         setSummary(null);
         setRepaymentSchedules([]);
@@ -165,27 +186,44 @@ export default function MyLoanManagement() {
           getJson<MyLoanRepaymentHistory[]>("/api/loans/me/repayment-histories"),
         ]);
 
-        setSummary(nextSummary);
-        setRepaymentSchedules(nextSchedules);
-        setRepaymentHistories(nextHistories);
+        if (requestId === loanManagementRequestIdRef.current) {
+          setSummary(nextSummary);
+          setRepaymentSchedules(nextSchedules);
+          setRepaymentHistories(nextHistories);
+        }
       } catch (error) {
-        setSummary(null);
-        setRepaymentSchedules([]);
-        setRepaymentHistories([]);
-        setLoanDataError(error instanceof Error ? error.message : "REQUEST_FAILED");
+        if (requestId === loanManagementRequestIdRef.current) {
+          setSummary(null);
+          setRepaymentSchedules([]);
+          setRepaymentHistories([]);
+          setLoanDataError(error instanceof Error ? error.message : "REQUEST_FAILED");
+        }
       } finally {
-        setIsLoanDataLoading(false);
+        if (requestId === loanManagementRequestIdRef.current) {
+          setIsLoanDataLoading(false);
+        }
       }
     };
 
+    const handleStorageChange = () => {
+      void syncLoanManagement();
+    };
     void syncLoanManagement();
     window.addEventListener("auth-change", syncLoanManagement);
     window.addEventListener("loan-application-change", syncLoanManagement);
+    window.addEventListener("storage", handleStorageChange);
     return () => {
       window.removeEventListener("auth-change", syncLoanManagement);
       window.removeEventListener("loan-application-change", syncLoanManagement);
+      window.removeEventListener("storage", handleStorageChange);
     };
   }, []);
+
+  useEffect(() => {
+    setSimulationAmount((currentAmount) =>
+      normalizeSimulationAmount(currentAmount, summary?.remainingPrincipal ?? 0),
+    );
+  }, [summary?.remainingPrincipal]);
 
   const repaidPrincipal = summary?.repaidPrincipal ?? 0;
   const repaymentProgress =
@@ -200,15 +238,35 @@ export default function MyLoanManagement() {
         : 0,
     [repaymentSchedules],
   );
+  const normalizedSimulationAmount = normalizeSimulationAmount(
+    simulationAmount,
+    summary?.remainingPrincipal ?? 0,
+  );
   const estimatedSavedMonths =
-    averagePrincipalPayment > 0 ? Math.floor(simulationAmount / averagePrincipalPayment) : 0;
+    averagePrincipalPayment > 0 ? Math.floor(normalizedSimulationAmount / averagePrincipalPayment) : 0;
   const estimatedInterestSavings = Math.round(
-    simulationAmount *
+    normalizedSimulationAmount *
       ((summary?.interestRate ?? 0) / 100) *
       (Math.max(estimatedSavedMonths, 1) / 12) *
       0.55,
   );
-  const remainingAfterSimulation = Math.max((summary?.remainingPrincipal ?? 0) - simulationAmount, 0);
+  const remainingAfterSimulation = Math.max(
+    (summary?.remainingPrincipal ?? 0) - normalizedSimulationAmount,
+    0,
+  );
+  const remainingInterestAmount = repaymentSchedules.reduce((sum, schedule) => {
+    if (schedule.settled) {
+      return sum;
+    }
+
+    return sum + Math.max(schedule.plannedInterest - schedule.paidInterest, 0);
+  }, 0);
+  const hasLoanData = !!summary;
+  const showLoanLoadingState = isLoanDataLoading && !hasLoanData;
+  const showLoanEmptyState =
+    !isLoanDataLoading &&
+    !hasLoanData &&
+    loanDataError === "대출 관리 정보가 없습니다.";
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -318,6 +376,25 @@ export default function MyLoanManagement() {
         </div>
 
         <div className="space-y-8 px-6 py-8 md:px-8 lg:px-10">
+          {showLoanLoadingState ? (
+            <section className="rounded-3xl border border-slate-200 bg-slate-50/80 px-6 py-8 text-center text-sm text-slate-500">
+              대출 관리 정보를 불러오는 중입니다.
+            </section>
+          ) : showLoanEmptyState ? (
+            <section className="rounded-3xl border border-dashed border-slate-200 bg-slate-50/80 px-6 py-8 text-center">
+              <h2 className="text-xl font-bold text-slate-900">대출 관리 정보가 없습니다</h2>
+              <p className="mt-2 text-sm text-slate-500">
+                현재 실행된 대출 데이터가 없어 관리 정보를 표시할 수 없습니다.
+              </p>
+              <Link
+                to="/loan/products"
+                className="mt-4 inline-block rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-[#5c7c97]"
+              >
+                대출 상품 보러가기
+              </Link>
+            </section>
+          ) : (
+            <>
           <section className="grid gap-4 md:grid-cols-4">
             <div className="rounded-3xl border border-sky-100 bg-sky-50/80 px-5 py-5">
               <p className="text-sm text-slate-500">잔여 원금</p>
@@ -364,14 +441,28 @@ export default function MyLoanManagement() {
                 min="0"
                 max={summary?.remainingPrincipal ?? 0}
                 step="100000"
-                value={simulationAmount}
-                onChange={(event) => setSimulationAmount(Number(event.target.value))}
+                value={normalizedSimulationAmount}
+                onChange={(event) =>
+                  setSimulationAmount(
+                    normalizeSimulationAmount(
+                      Number(event.target.value),
+                      summary?.remainingPrincipal ?? 0,
+                    ),
+                  )
+                }
                 className="w-full accent-sky-600"
               />
               <input
                 type="number"
-                value={simulationAmount}
-                onChange={(event) => setSimulationAmount(Number(event.target.value))}
+                value={normalizedSimulationAmount}
+                onChange={(event) =>
+                  setSimulationAmount(
+                    normalizeSimulationAmount(
+                      Number(event.target.value),
+                      summary?.remainingPrincipal ?? 0,
+                    ),
+                  )
+                }
                 className="mt-4 h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-sky-400 focus:ring-4 focus:ring-sky-100"
               />
 
@@ -495,27 +586,74 @@ export default function MyLoanManagement() {
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
                   <p className="text-sm text-slate-500">잔여 예상 이자</p>
                   <p className="mt-2 text-2xl font-bold text-slate-900">
-                    {formatAmount(
-                      repaymentSchedules.reduce((sum, schedule) => {
-                        if (schedule.settled) {
-                          return sum;
-                        }
-                        return sum + schedule.plannedInterest;
-                      }, 0),
-                    )}
+                    {formatAmount(remainingInterestAmount)}
                   </p>
                 </div>
               </div>
             </div>
           </section>
 
-          {isLoanDataLoading && (
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+            <h2 className="text-xl font-bold text-slate-900">상환 일정</h2>
+            <div className="mt-5 space-y-3">
+              {repaymentSchedules.map((schedule) => (
+                <div
+                  key={schedule.scheduleId}
+                  className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
+                >
+                  <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-sm text-slate-500">{schedule.dueDate}</p>
+                      <p className="mt-1 text-base font-semibold text-slate-900">
+                        {schedule.settled ? "납부 완료" : "납부 예정"}
+                      </p>
+                    </div>
+                    <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-2 lg:grid-cols-4">
+                      <div>
+                        <p className="text-slate-500">예정 원금</p>
+                        <p className="mt-1 font-semibold text-slate-900">
+                          {formatAmount(schedule.plannedPrincipal)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-500">예정 이자</p>
+                        <p className="mt-1 font-semibold text-slate-900">
+                          {formatAmount(schedule.plannedInterest)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-500">납부 원금</p>
+                        <p className="mt-1 font-semibold text-slate-900">
+                          {formatAmount(schedule.paidPrincipal)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-500">납부 이자</p>
+                        <p className="mt-1 font-semibold text-slate-900">
+                          {formatAmount(schedule.paidInterest)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+              {repaymentSchedules.length === 0 && (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-5 text-sm text-slate-500">
+                  상환 일정이 없습니다.
+                </div>
+              )}
+            </div>
+          </section>
+            </>
+          )}
+
+          {isLoanDataLoading && hasLoanData && (
             <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-4 text-sm text-slate-500">
               대출 관리 정보를 불러오는 중입니다.
             </div>
           )}
 
-          {loanDataError && !isLoanDataLoading && (
+          {loanDataError && !isLoanDataLoading && !showLoanEmptyState && (
             <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800">
               {loanDataError === "대출 관리 정보가 없습니다."
                 ? "현재 조회할 대출 관리 정보가 없습니다."

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -27,25 +27,39 @@ type CertificateSubmissionResponse = {
   submittedAt: string;
 };
 
-const loanInfo = {
-  totalPrincipal: 20000000,
-  remainingPrincipal: 15000000,
-  monthlyPayment: 450000,
-  interestRate: 3.5,
-  maturityDate: "2028-03-24",
-  nextPaymentDate: "2026-04-25",
-  nextPaymentAmount: 450000,
-  cumulativeInterest: 1320000,
-  estimatedRemainingInterest: 1840000,
-  repaymentType: "원리금균등상환",
-  autoDebitAccount: "110-294-882104",
+type MyLoanSummary = {
+  loanHistoryId: number;
+  status: string;
+  totalPrincipal: number;
+  remainingPrincipal: number;
+  repaidPrincipal: number;
+  interestRate: number;
+  startDate: string;
+  endDate: string;
+  nextPaymentDate: string | null;
+  nextPaymentAmount: number;
+  cumulativeInterest: number;
+  repaymentAccountNumber: string;
 };
 
-const recentRepayments = [
-  { date: "2026-03-25", amount: 450000, principal: 338000, interest: 112000 },
-  { date: "2026-02-25", amount: 450000, principal: 335000, interest: 115000 },
-  { date: "2026-01-25", amount: 450000, principal: 331000, interest: 119000 },
-];
+type MyLoanRepaymentSchedule = {
+  scheduleId: number;
+  dueDate: string;
+  plannedPrincipal: number;
+  plannedInterest: number;
+  paidPrincipal: number;
+  paidInterest: number;
+  settled: boolean;
+  overdueDays: number | null;
+};
+
+type MyLoanRepaymentHistory = {
+  repaymentId: number;
+  repaymentAmount: number;
+  repaymentRate: number;
+  repaymentDatetime: string;
+  remainingBalance: number;
+};
 
 const certificateGroups = [
   { label: "사무/기초", options: [{ id: "1", label: "컴퓨터활용능력 1급" }, { id: "2", label: "컴퓨터활용능력 2급" }, { id: "3", label: "워드프로세서" }, { id: "4", label: "한국사능력검정시험" }] },
@@ -97,6 +111,11 @@ export default function MyLoanManagement() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [simulationAmount, setSimulationAmount] = useState(1000000);
   const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
+  const [summary, setSummary] = useState<MyLoanSummary | null>(null);
+  const [repaymentSchedules, setRepaymentSchedules] = useState<MyLoanRepaymentSchedule[]>([]);
+  const [repaymentHistories, setRepaymentHistories] = useState<MyLoanRepaymentHistory[]>([]);
+  const [isLoanDataLoading, setIsLoanDataLoading] = useState(false);
+  const [loanDataError, setLoanDataError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -126,31 +145,80 @@ export default function MyLoanManagement() {
     };
   }, []);
 
-  const repaidPrincipal = loanInfo.totalPrincipal - loanInfo.remainingPrincipal;
-  const repaymentProgress = (repaidPrincipal / loanInfo.totalPrincipal) * 100;
+  useEffect(() => {
+    const syncLoanManagement = async () => {
+      if (localStorage.getItem("isLoggedIn") !== "true") {
+        setSummary(null);
+        setRepaymentSchedules([]);
+        setRepaymentHistories([]);
+        setLoanDataError(null);
+        return;
+      }
+
+      setIsLoanDataLoading(true);
+      setLoanDataError(null);
+
+      try {
+        const [nextSummary, nextSchedules, nextHistories] = await Promise.all([
+          getJson<MyLoanSummary>("/api/loans/me/summary"),
+          getJson<MyLoanRepaymentSchedule[]>("/api/loans/me/repayment-schedules"),
+          getJson<MyLoanRepaymentHistory[]>("/api/loans/me/repayment-histories"),
+        ]);
+
+        setSummary(nextSummary);
+        setRepaymentSchedules(nextSchedules);
+        setRepaymentHistories(nextHistories);
+      } catch (error) {
+        setSummary(null);
+        setRepaymentSchedules([]);
+        setRepaymentHistories([]);
+        setLoanDataError(error instanceof Error ? error.message : "REQUEST_FAILED");
+      } finally {
+        setIsLoanDataLoading(false);
+      }
+    };
+
+    void syncLoanManagement();
+    window.addEventListener("auth-change", syncLoanManagement);
+    window.addEventListener("loan-application-change", syncLoanManagement);
+    return () => {
+      window.removeEventListener("auth-change", syncLoanManagement);
+      window.removeEventListener("loan-application-change", syncLoanManagement);
+    };
+  }, []);
+
+  const repaidPrincipal = summary?.repaidPrincipal ?? 0;
+  const repaymentProgress =
+    summary && summary.totalPrincipal > 0 ? (repaidPrincipal / summary.totalPrincipal) * 100 : 0;
   const averagePrincipalPayment = useMemo(
     () =>
-      Math.round(
-        recentRepayments.reduce((sum, item) => sum + item.principal, 0) /
-          recentRepayments.length,
-      ),
-    [],
+      repaymentSchedules.length > 0
+        ? Math.round(
+            repaymentSchedules.reduce((sum, item) => sum + item.plannedPrincipal, 0) /
+              repaymentSchedules.length,
+          )
+        : 0,
+    [repaymentSchedules],
   );
   const estimatedSavedMonths =
     averagePrincipalPayment > 0 ? Math.floor(simulationAmount / averagePrincipalPayment) : 0;
   const estimatedInterestSavings = Math.round(
     simulationAmount *
-      (loanInfo.interestRate / 100) *
+      ((summary?.interestRate ?? 0) / 100) *
       (Math.max(estimatedSavedMonths, 1) / 12) *
       0.55,
   );
-  const remainingAfterSimulation = Math.max(loanInfo.remainingPrincipal - simulationAmount, 0);
+  const remainingAfterSimulation = Math.max((summary?.remainingPrincipal ?? 0) - simulationAmount, 0);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  const nextPaymentDate = new Date(`${loanInfo.nextPaymentDate}T00:00:00`);
+  const nextPaymentDate = summary?.nextPaymentDate
+    ? new Date(`${summary.nextPaymentDate}T00:00:00`)
+    : null;
   const daysUntilNextPayment = Math.max(
-    Math.ceil((nextPaymentDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
+    nextPaymentDate
+      ? Math.ceil((nextPaymentDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+      : 0,
     0,
   );
 
@@ -254,13 +322,13 @@ export default function MyLoanManagement() {
             <div className="rounded-3xl border border-sky-100 bg-sky-50/80 px-5 py-5">
               <p className="text-sm text-slate-500">잔여 원금</p>
               <p className="mt-3 text-3xl font-semibold text-slate-900">
-                {formatAmount(loanInfo.remainingPrincipal)}
+                {formatAmount(summary?.remainingPrincipal ?? 0)}
               </p>
             </div>
             <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
               <p className="text-sm text-slate-500">총 원금</p>
               <p className="mt-3 text-2xl font-bold text-slate-900">
-                {formatAmount(loanInfo.totalPrincipal)}
+                {formatAmount(summary?.totalPrincipal ?? 0)}
               </p>
             </div>
             <div className="rounded-3xl border border-emerald-100 bg-emerald-50/80 px-5 py-5">
@@ -272,7 +340,7 @@ export default function MyLoanManagement() {
             <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
               <p className="text-sm text-slate-500">금리</p>
               <p className="mt-3 text-2xl font-bold text-slate-900">
-                연 {loanInfo.interestRate.toFixed(1)}%
+                연 {(summary?.interestRate ?? 0).toFixed(1)}%
               </p>
             </div>
           </section>
@@ -294,7 +362,7 @@ export default function MyLoanManagement() {
               <input
                 type="range"
                 min="0"
-                max={loanInfo.remainingPrincipal}
+                max={summary?.remainingPrincipal ?? 0}
                 step="100000"
                 value={simulationAmount}
                 onChange={(event) => setSimulationAmount(Number(event.target.value))}
@@ -367,7 +435,7 @@ export default function MyLoanManagement() {
               <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50/60 px-4 py-4">
                 <p className="text-sm text-slate-500">다음 납입 예정일</p>
                 <p className="mt-2 text-lg font-semibold text-slate-900">
-                  {loanInfo.nextPaymentDate} / {formatAmount(loanInfo.nextPaymentAmount)}
+                  {(summary?.nextPaymentDate ?? "-")} / {formatAmount(summary?.nextPaymentAmount ?? 0)}
                 </p>
                 <p className="mt-2 text-sm text-slate-600">
                   오늘 기준 {daysUntilNextPayment}일 남았습니다.
@@ -380,33 +448,38 @@ export default function MyLoanManagement() {
             <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
               <h2 className="text-xl font-bold text-slate-900">최근 상환 내역</h2>
               <div className="mt-5 space-y-3">
-                {recentRepayments.map((repayment) => (
+                {repaymentHistories.map((repayment) => (
                   <div
-                    key={repayment.date}
+                    key={repayment.repaymentId}
                     className="flex flex-col gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4 md:flex-row md:items-center md:justify-between"
                   >
                     <div>
-                      <p className="text-sm text-slate-500">{repayment.date}</p>
+                      <p className="text-sm text-slate-500">{repayment.repaymentDatetime.slice(0, 10)}</p>
                       <p className="mt-1 text-lg font-semibold text-slate-900">
-                        {formatAmount(repayment.amount)}
+                        {formatAmount(repayment.repaymentAmount)}
                       </p>
                     </div>
                     <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-2 md:gap-8">
                       <div>
                         <p className="text-slate-500">원금</p>
                         <p className="mt-1 font-semibold text-slate-900">
-                          {formatAmount(repayment.principal)}
+                          -
                         </p>
                       </div>
                       <div>
                         <p className="text-slate-500">이자</p>
                         <p className="mt-1 font-semibold text-slate-900">
-                          {formatAmount(repayment.interest)}
+                          -
                         </p>
                       </div>
                     </div>
                   </div>
                 ))}
+                {repaymentHistories.length === 0 && (
+                  <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-5 text-sm text-slate-500">
+                    상환 내역이 없습니다.
+                  </div>
+                )}
               </div>
             </div>
 
@@ -416,18 +489,39 @@ export default function MyLoanManagement() {
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
                   <p className="text-sm text-slate-500">누적 납입 이자</p>
                   <p className="mt-2 text-2xl font-bold text-slate-900">
-                    {formatAmount(loanInfo.cumulativeInterest)}
+                    {formatAmount(summary?.cumulativeInterest ?? 0)}
                   </p>
                 </div>
                 <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
                   <p className="text-sm text-slate-500">잔여 예상 이자</p>
                   <p className="mt-2 text-2xl font-bold text-slate-900">
-                    {formatAmount(loanInfo.estimatedRemainingInterest)}
+                    {formatAmount(
+                      repaymentSchedules.reduce((sum, schedule) => {
+                        if (schedule.settled) {
+                          return sum;
+                        }
+                        return sum + schedule.plannedInterest;
+                      }, 0),
+                    )}
                   </p>
                 </div>
               </div>
             </div>
           </section>
+
+          {isLoanDataLoading && (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-4 text-sm text-slate-500">
+              대출 관리 정보를 불러오는 중입니다.
+            </div>
+          )}
+
+          {loanDataError && !isLoanDataLoading && (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800">
+              {loanDataError === "대출 관리 정보가 없습니다."
+                ? "현재 조회할 대출 관리 정보가 없습니다."
+                : loanDataError}
+            </div>
+          )}
 
           {selfDevelopmentApplication && (
             <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #39 

---

### 📝 작업 내용
- 내 대출 관리 페이지의 목업 데이터를 실제 API 응답 기반으로 교체
- 대출 요약 정보, 다음 납입 예정일, 최근 상환 내역을 실데이터로 연동
- 로딩 및 대출 관리 데이터 조회 에러 상태를 화면에 표시하도록 처리
---

### 📷 스크린샷 (선택)
- <img width="1231" height="316" alt="image" src="https://github.com/user-attachments/assets/12224a6f-2a55-449b-9381-bdef1e6679c5" />
- 
<img width="455" height="441" alt="image" src="https://github.com/user-attachments/assets/f616e9b4-0dd5-4960-a237-8f7d013995b7" />


---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 대출 관리 페이지가 서버의 실시간 요약, 상환 일정, 상환 내역으로 동기화됩니다.
  * 상환 진행도·시뮬레이션·잔액/예상 이자 계산이 조회된 데이터로 표시됩니다.
  * 상환 일정과 내역이 목록으로 렌더링되며 상태(정산 여부 등)가 표시됩니다
  * 데이터 로딩 배너, 빈 상태(네비게이션 링크 포함) 및 오류 배너가 추가되어 사용자 피드백이 강화되었습니다.
  * 브라우저 저장소 변경 시 동기화가 재실행되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->