### PR TITLE
Feat: 마이페이지 구현, 헤더, 카드홀더 조정

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -82,6 +82,21 @@ export default function Header() {
     };
   }, []);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1180px)");
+    const syncMenuStateByViewport = () => {
+      if (mediaQuery.matches) {
+        setIsMobileMenuOpen(false);
+      } else {
+        setActiveMenuLabel(null);
+      }
+    };
+
+    syncMenuStateByViewport();
+    mediaQuery.addEventListener("change", syncMenuStateByViewport);
+    return () => mediaQuery.removeEventListener("change", syncMenuStateByViewport);
+  }, []);
+
   const handleLogout = async () => {
     try {
       await postJson<{ ok: boolean }>("/api/auth/logout", {});
@@ -223,7 +238,7 @@ export default function Header() {
         </header>
 
         {activeMenuLabel && (
-          <div className="pointer-events-none fixed inset-0 top-16 z-30 bg-black/20 backdrop-blur-sm" />
+          <div className="pointer-events-none fixed inset-0 top-16 z-30 hidden bg-black/20 backdrop-blur-sm min-[1180px]:block" />
         )}
 
         {activeMenuLabel && (

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -114,12 +114,12 @@ export default function Header() {
       >
         <header className="border-b border-white/20 bg-gray-900/80 shadow-lg backdrop-blur-md">
           <div className="mx-auto max-w-7xl px-4">
-            <div className="grid h-16 grid-cols-[1fr_auto] items-center gap-4 sm:grid-cols-[150px_1fr_220px] lg:grid-cols-[180px_1fr_280px]">
+            <div className="grid h-16 grid-cols-[1fr_auto] items-center gap-4 min-[1180px]:grid-cols-[150px_1fr_220px] min-[1280px]:grid-cols-[180px_1fr_280px]">
               <Link to="/" className="text-2xl font-bold text-white drop-shadow-lg">
                 NUDGEBANK
               </Link>
 
-              <nav className="hidden items-center justify-center sm:flex">
+              <nav className="hidden items-center justify-center min-[1180px]:flex">
                 <div
                     className="mx-auto flex w-full items-center justify-center gap-6 md:gap-10 lg:gap-14"
                     style={{ maxWidth: `${MENU_TRACK_WIDTH}px` }}
@@ -134,7 +134,7 @@ export default function Header() {
                         <Link
                           to={getPrimaryPath(item) || "#"}
                           onFocus={() => setActiveMenuLabel(item.label)}
-                          className="py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
+                          className="whitespace-nowrap py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
                         >
                           {item.label}
                         </Link>
@@ -147,14 +147,14 @@ export default function Header() {
                           onClick={() =>
                             setActiveMenuLabel((current) => (current === item.label ? null : item.label))
                           }
-                          className="py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
+                          className="whitespace-nowrap py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
                         >
                           {item.label}
                         </button>
                       ) : (
                         <Link
                           to={item.path || "#"}
-                          className="py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
+                          className="whitespace-nowrap py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
                         >
                           {item.label}
                         </Link>
@@ -164,7 +164,7 @@ export default function Header() {
                 </div>
               </nav>
 
-              <div className="hidden items-center justify-end gap-2 lg:gap-3 sm:flex">
+              <div className="hidden items-center justify-end gap-2 lg:gap-3 min-[1180px]:flex">
                 {isLoggedIn ? (
                   <>
                     <Link
@@ -192,7 +192,7 @@ export default function Header() {
                 )}
               </div>
 
-              <div className="flex items-center justify-end gap-2 sm:hidden">
+              <div className="flex items-center justify-end gap-2 min-[1180px]:hidden">
                 {isLoggedIn ? (
                   <Link
                     to="/account/mypage"
@@ -227,7 +227,7 @@ export default function Header() {
         )}
 
         {activeMenuLabel && (
-          <div className="absolute left-0 right-0 top-full z-40 hidden border-b border-white/20 bg-gray-800/50 shadow-2xl backdrop-blur-xl sm:block">
+          <div className="absolute left-0 right-0 top-full z-40 hidden border-b border-white/20 bg-gray-800/50 shadow-2xl backdrop-blur-xl min-[1180px]:block">
             <div className="mx-auto max-w-7xl px-4 py-6">
               <div className="grid min-h-[116px] grid-cols-[180px_1fr_280px] items-start gap-4">
                 <div className="pt-1">
@@ -269,7 +269,7 @@ export default function Header() {
         )}
 
         {isMobileMenuOpen && (
-          <div className="border-b border-white/20 bg-gray-900/95 shadow-2xl backdrop-blur-md sm:hidden">
+          <div className="border-b border-white/20 bg-gray-900/95 shadow-2xl backdrop-blur-md min-[1180px]:hidden">
             <div className="mx-auto max-w-7xl px-4 py-4">
               <div className="space-y-5">
                 {menuItems.map((item) => (

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -99,12 +99,12 @@ function maskCardNumber(cardNumber: string | null) {
     return "미발급";
   }
 
-  const parts = cardNumber.split("-");
-  if (parts.length !== 4) {
-    return cardNumber;
+  const digitsOnly = cardNumber.replace(/\D/g, "");
+  if (digitsOnly.length < 8) {
+    return "****-****-****-****";
   }
 
-  return `${parts[0]}-****-****-${parts[3]}`;
+  return `${digitsOnly.slice(0, 4)}-****-****-${digitsOnly.slice(-4)}`;
 }
 
 export default function MyPage() {

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -1,167 +1,560 @@
-import { BadgeCheck, CreditCard, FileText, User } from "lucide-react";
+import { BadgeCheck, ChevronDown, ChevronUp, CreditCard, FileText, User } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router";
+
+import { getJson, postJson } from "../../lib/api";
+
+type MyProfile = {
+  memberId: number;
+  loginId: string;
+  name: string;
+  birth: string | null;
+  gender: string | null;
+  phoneNumber: string | null;
+};
+
+type CardHistoryResponse = {
+  ok: boolean;
+  message: string;
+  accounts: CardHistoryAccount[];
+};
+
+type CardHistoryAccount = {
+  accountId: number;
+  accountName: string;
+  accountNumber: string;
+  balance: number;
+  cardId: number | null;
+  cardNumber: string | null;
+  expiredYm: string | null;
+  cardStatus: string | null;
+  spentThisMonth: number;
+};
+
+type AuthResponse = {
+  ok: boolean;
+  message: string;
+};
+
+type MyLoanSummary = {
+  loanHistoryId: number;
+  status: string;
+  totalPrincipal: number;
+  remainingPrincipal: number;
+  repaidPrincipal: number;
+  interestRate: number;
+  startDate: string;
+  endDate: string;
+  nextPaymentDate: string | null;
+  nextPaymentAmount: number;
+  cumulativeInterest: number;
+  repaymentAccountNumber: string;
+};
 
 const quickMenus = [
   {
     title: "회원정보 관리",
-    description: "기본 회원 정보와 최근 이용 상태를 확인합니다.",
+    description: "기본 정보 확인",
     icon: User,
+    to: "/account/mypage",
   },
   {
     title: "대출 관리",
-    description: "진행 중인 대출과 상환 일정을 확인합니다.",
+    description: "대출 현황 확인",
     icon: FileText,
+    to: "/loan/management",
   },
   {
     title: "카드 이용내역",
-    description: "최근 결제 내역과 카드 사용 흐름을 조회합니다.",
+    description: "결제 내역 확인",
     icon: CreditCard,
+    to: "/card/history",
   },
   {
     title: "인증 결과 조회",
-    description: "서류 제출 결과와 인증 진행 상태를 확인합니다.",
+    description: "서류 결과 확인",
     icon: BadgeCheck,
+    to: "/loan/management",
   },
-];
+] as const;
+
+function formatBirth(birth: string | null) {
+  return birth || "등록 전";
+}
+
+function formatPhoneNumber(phoneNumber: string | null) {
+  return phoneNumber || "등록 전";
+}
+
+function formatGender(gender: string | null) {
+  return gender || "등록 전";
+}
+
+function formatAmount(amount: number) {
+  return `${amount.toLocaleString("ko-KR")}원`;
+}
+
+function maskCardNumber(cardNumber: string | null) {
+  if (!cardNumber) {
+    return "미발급";
+  }
+
+  const parts = cardNumber.split("-");
+  if (parts.length !== 4) {
+    return cardNumber;
+  }
+
+  return `${parts[0]}-****-****-${parts[3]}`;
+}
 
 export default function MyPage() {
+  const [profile, setProfile] = useState<MyProfile | null>(null);
+  const [accounts, setAccounts] = useState<CardHistoryAccount[]>([]);
+  const [loanSummary, setLoanSummary] = useState<MyLoanSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isShowingAllCardNumbers, setIsShowingAllCardNumbers] = useState(false);
+  const [isRevealFormOpen, setIsRevealFormOpen] = useState(false);
+  const [accountPasswordInput, setAccountPasswordInput] = useState("");
+  const [accountPasswordError, setAccountPasswordError] = useState("");
+  const [isVerifyingPassword, setIsVerifyingPassword] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isContactOpen, setIsContactOpen] = useState(false);
+  const [isBankingOpen, setIsBankingOpen] = useState(false);
+  const [isLoanOpen, setIsLoanOpen] = useState(false);
+  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadProfile() {
+      setIsLoading(true);
+      setErrorMessage("");
+
+      try {
+        const [profileResponse, cardHistoryResponse, loanSummaryResponse] = await Promise.all([
+          getJson<MyProfile>("/api/auth/me"),
+          getJson<CardHistoryResponse>("/api/cards/history"),
+          getJson<MyLoanSummary>("/api/loans/me/summary").catch(() => null),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setProfile(profileResponse);
+        setAccounts(cardHistoryResponse.accounts);
+        setLoanSummary(loanSummaryResponse);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : "REQUEST_FAILED";
+        setProfile(null);
+        setAccounts([]);
+        setLoanSummary(null);
+        setErrorMessage(
+          message === "UNAUTHORIZED"
+            ? "로그인 후 마이페이지를 확인할 수 있습니다."
+            : "사용자 정보를 불러오지 못했습니다.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const issuedCards = accounts.filter((account) => account.cardId);
+  const totalBalance = accounts.reduce((sum, account) => sum + account.balance, 0);
+  const sectionToggleClass =
+    "flex items-center justify-center p-0 text-slate-400 transition hover:text-slate-600";
+
+  const handleOpenRevealForm = () => {
+    setIsRevealFormOpen(true);
+    setAccountPasswordInput("");
+    setAccountPasswordError("");
+  };
+
+  const handleConfirmReveal = async () => {
+    if (!accountPasswordInput.trim()) {
+      setAccountPasswordError("계정 비밀번호를 입력해 주세요.");
+      return;
+    }
+
+    setIsVerifyingPassword(true);
+    setAccountPasswordError("");
+
+    try {
+      await postJson<AuthResponse>("/api/auth/verify-password", {
+        password: accountPasswordInput,
+      });
+      setIsShowingAllCardNumbers(true);
+      setIsRevealFormOpen(false);
+      setAccountPasswordInput("");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "REQUEST_FAILED";
+      setAccountPasswordError(
+        message === "INVALID_CREDENTIALS"
+          ? "계정 비밀번호가 일치하지 않습니다."
+          : "비밀번호 확인 중 오류가 발생했습니다.",
+      );
+    } finally {
+      setIsVerifyingPassword(false);
+    }
+  };
+
+  const handleHideAllCardNumbers = () => {
+    setIsShowingAllCardNumbers(false);
+    setIsRevealFormOpen(false);
+    setAccountPasswordInput("");
+    setAccountPasswordError("");
+  };
+
   return (
-    <div className="min-h-screen">
-      <div className="mx-auto max-w-7xl px-4 py-12">
-        <div className="mb-12">
-          <div className="mb-4 flex items-center gap-3">
-            <div className="rounded-full border-2 border-white/30 bg-white/20 p-3 shadow-lg backdrop-blur-md">
-              <User className="h-8 w-8 text-white" />
+    <div className="mx-auto max-w-6xl px-4 py-10 md:px-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-200/80 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+        <div className="border-b border-slate-100 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.14),_transparent_38%),linear-gradient(135deg,_#f8fbff_0%,_#ffffff_52%,_#f8fafc_100%)] px-6 py-6 md:px-8">
+          <div>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight text-slate-900">마이페이지</h1>
+              <p className="mt-2 text-sm text-slate-500">
+                내 정보와 계좌, 카드 정보를 한 번에 확인할 수 있습니다.
+              </p>
             </div>
-            <h1 className="text-4xl font-bold text-slate-900 drop-shadow-lg">마이페이지</h1>
           </div>
-          <p className="ml-16 text-xl text-slate-600 drop-shadow-lg">
-            내 정보와 금융 이용 현황을 한 곳에서 확인할 수 있습니다.
-          </p>
-        </div>
 
-        <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <section className="lg:col-span-2 rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
-            <div className="mb-8 flex items-start justify-between gap-6">
-              <div className="flex-1">
-                <div className="mb-4 flex items-center gap-3">
-                  <h2 className="text-2xl font-bold text-slate-900">내 금융 현황</h2>
-                  <span className="rounded-full bg-blue-100 px-4 py-1 text-sm font-semibold text-slate-900 shadow-md">
-                    요약 보기
-                  </span>
-                </div>
-
-                <div className="mb-6">
-                  <div className="mb-2 text-5xl font-bold text-blue-600">NUDGE CARE</div>
-                  <p className="text-base text-slate-600">
-                    계좌, 대출, 카드 이용 상태를 빠르게 확인하고 필요한 메뉴로 바로 이동할 수 있습니다.
-                  </p>
-                </div>
-
-                <div className="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-3">
-                  <div>
-                    <p className="mb-1 text-sm text-slate-500">보유 계좌</p>
-                    <p className="text-2xl font-bold text-slate-900">2개</p>
-                  </div>
-                  <div>
-                    <p className="mb-1 text-sm text-slate-500">이용 중 대출</p>
-                    <p className="text-2xl font-bold text-slate-900">1건</p>
-                  </div>
-                  <div>
-                    <p className="mb-1 text-sm text-slate-500">최근 확인 항목</p>
-                    <p className="text-2xl font-bold text-slate-900">대출 관리</p>
-                  </div>
-                </div>
-
-                <div className="mb-6 flex flex-wrap gap-2">
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
-                    계좌 조회
-                  </span>
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
-                    대출 현황
-                  </span>
-                  <span className="rounded-lg bg-white px-4 py-2 text-sm text-slate-700 shadow-sm">
-                    카드 내역
-                  </span>
-                </div>
-              </div>
-
-              <div className="relative hidden h-64 w-64 flex-shrink-0 items-center justify-center md:flex">
-                <div className="absolute h-32 w-48 rounded-[40%_60%_70%_30%/60%_30%_70%_40%] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-700 opacity-80 shadow-2xl blur-sm" />
-                <div className="absolute h-28 w-40 rounded-[60%_40%_30%_70%/40%_70%_30%_60%] bg-gradient-to-br from-blue-300 via-blue-400 to-blue-600 shadow-xl" />
-              </div>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <div className="rounded-3xl border border-sky-100 bg-[linear-gradient(135deg,_rgba(219,234,254,0.95)_0%,_rgba(239,246,255,0.98)_48%,_rgba(248,250,252,1)_100%)] px-5 py-5 text-slate-900 shadow-[0_20px_45px_rgba(148,163,184,0.18)]">
+              <p className="text-sm text-slate-500">보유 계좌 · 카드</p>
+              <p className="mt-3 text-3xl font-semibold">{accounts.length}개</p>
             </div>
-
-            <div className="flex gap-4">
-              <Link
-                to="/mypage"
-                className="flex-1 rounded-xl bg-white py-4 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
-              >
-                내 정보 보기
-              </Link>
-              <Link
-                to="/loan/management"
-                className="flex-1 rounded-xl bg-blue-100 py-4 text-center font-bold text-slate-900 shadow-md transition-all hover:bg-blue-200"
-              >
-                대출 관리로 이동
-              </Link>
+            <div className="rounded-3xl border border-blue-100 bg-blue-50/70 px-5 py-5">
+              <p className="text-sm text-slate-500">총 예금 잔액</p>
+              <p className="mt-3 text-3xl font-semibold text-slate-900">{formatAmount(totalBalance)}</p>
             </div>
-          </section>
-
-          <div className="space-y-6">
-            <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
-              <h3 className="mb-4 text-xl font-bold text-slate-900">대출 현황</h3>
-              <div className="mb-4 text-3xl font-bold text-blue-600">상환 진행 중</div>
-              <div className="mb-6 space-y-2 text-slate-600">
-                <p>진행 중인 대출 1건</p>
-                <p>다음 납입일 2026.04.25</p>
-                <p>내 대출 관리에서 상세 확인 가능</p>
-              </div>
-              <Link
-                to="/loan/management"
-                className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
-              >
-                상세 보기
-              </Link>
-            </section>
-
-            <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-6 shadow-2xl backdrop-blur-lg">
-              <h3 className="mb-4 text-xl font-bold text-slate-900">알림</h3>
-              <div className="mb-6 space-y-2 text-slate-600">
-                <p>제출 서류와 인증 결과는 대출 관리에서 확인할 수 있습니다.</p>
-                <p>상품 신청 상태에 따라 추가 안내가 표시됩니다.</p>
-              </div>
-              <Link
-                to="/loan/management"
-                className="block w-full rounded-xl bg-white py-3 text-center font-bold text-slate-900 shadow-sm transition-all hover:bg-white/90"
-              >
-                확인하러 가기
-              </Link>
-            </section>
           </div>
         </div>
 
-        <section className="rounded-3xl border-2 border-white/40 bg-white/60 p-8 shadow-2xl backdrop-blur-lg">
-          <div className="mb-6">
-            <p className="mb-2 text-sm text-slate-500">빠른 메뉴</p>
-            <h2 className="text-2xl font-bold text-slate-900">자주 찾는 서비스</h2>
+        {isLoading ? (
+          <div className="px-6 py-16 text-center text-sm text-slate-500 md:px-8">
+            사용자 정보를 불러오는 중입니다.
           </div>
+        ) : errorMessage ? (
+          <div className="px-6 py-16 text-center md:px-8">
+            <p className="text-sm font-medium text-rose-600">{errorMessage}</p>
+            <Link
+              to="/login"
+              className="mt-4 inline-flex rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#5c7c97]"
+            >
+              로그인하러 가기
+            </Link>
+          </div>
+        ) : profile ? (
+          <div className="space-y-8 px-6 py-8 md:px-8 lg:px-10">
+            <section className="grid items-start gap-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+              <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                <button
+                  type="button"
+                  onClick={() => setIsProfileOpen((prev) => !prev)}
+                  className="flex w-full items-center justify-between gap-4 text-left"
+                >
+                  <h2 className="text-2xl font-bold text-slate-900">기본 정보</h2>
+                  <span className={sectionToggleClass}>
+                    {isProfileOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                  </span>
+                </button>
+                {isProfileOpen && (
+                  <div className="mt-6 grid gap-4 md:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">회원 번호</p>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">{profile.memberId}</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">아이디</p>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">{profile.loginId}</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">생년월일</p>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">
+                        {formatBirth(profile.birth)}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">성별</p>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">
+                        {formatGender(profile.gender)}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
 
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
-            {quickMenus.map(({ title, description, icon: Icon }) => (
-              <article
-                key={title}
-                className="rounded-2xl border border-white/70 bg-white/80 p-6 shadow-lg transition-all hover:shadow-xl"
+              <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                <button
+                  type="button"
+                  onClick={() => setIsContactOpen((prev) => !prev)}
+                  className="flex w-full items-center justify-between gap-4 text-left"
+                >
+                  <h2 className="text-2xl font-bold text-slate-900">연락 정보</h2>
+                  <span className={sectionToggleClass}>
+                    {isContactOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                  </span>
+                </button>
+                {isContactOpen && (
+                  <div className="mt-6 space-y-4">
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">전화번호</p>
+                      <p className="mt-2 text-lg font-semibold text-slate-900">
+                        {formatPhoneNumber(profile.phoneNumber)}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <button
+                type="button"
+                onClick={() => setIsLoanOpen((prev) => !prev)}
+                className="flex w-full items-center justify-between gap-4 text-left"
               >
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
-                  <Icon className="h-6 w-6 text-blue-600" />
+                <h2 className="text-2xl font-bold text-slate-900">대출</h2>
+                <span className={sectionToggleClass}>
+                  {isLoanOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                </span>
+              </button>
+              {isLoanOpen && (
+                <div className="mt-6 grid gap-4 md:grid-cols-2">
+                  <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                    <p className="text-sm text-slate-500">잔여 원금</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-900">
+                      {loanSummary ? formatAmount(loanSummary.remainingPrincipal) : "대출 정보 없음"}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                    <p className="text-sm text-slate-500">누적 상환액</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-900">
+                      {loanSummary ? formatAmount(loanSummary.repaidPrincipal) : "대출 정보 없음"}
+                    </p>
+                  </div>
                 </div>
-                <h3 className="mb-2 text-xl font-bold text-slate-900">{title}</h3>
-                <p className="text-sm leading-6 text-slate-600">{description}</p>
-              </article>
-            ))}
+              )}
+            </section>
+
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <button
+                type="button"
+                onClick={() => setIsBankingOpen((prev) => !prev)}
+                className="flex w-full items-center justify-between gap-4 text-left"
+              >
+                <h2 className="text-2xl font-bold text-slate-900">계좌 및 카드</h2>
+                <span className={sectionToggleClass}>
+                  {isBankingOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                </span>
+              </button>
+
+              {isBankingOpen && (
+                <div className="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+                  <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                    <div className="mb-6">
+                      <h3 className="text-2xl font-bold text-slate-900">계좌</h3>
+                    </div>
+
+                    {accounts.length > 0 ? (
+                      <div className="space-y-4">
+                        {accounts.map((account) => (
+                          <div
+                            key={account.accountId}
+                            className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-3"
+                          >
+                            <div className="flex items-start justify-between gap-4">
+                              <div>
+                                <p className="text-base font-semibold text-slate-900">{account.accountName}</p>
+                                <p className="mt-1 text-sm text-slate-500">{account.accountNumber}</p>
+                              </div>
+                            </div>
+                            <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                              <div>
+                                <p className="text-slate-500">계좌 상태</p>
+                                <p className="mt-1 font-semibold text-slate-900">정상</p>
+                              </div>
+                              <div>
+                                <p className="text-slate-500">잔액</p>
+                                <p className="mt-1 font-semibold text-slate-900">
+                                  {formatAmount(account.balance)}
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-5 py-6">
+                        <p className="text-sm text-slate-500">현재 보유한 계좌가 없습니다.</p>
+                        <Link
+                          to="/account/ddokgae"
+                          className="mt-4 inline-flex rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#5c7c97]"
+                        >
+                          계좌 개설하러 가기
+                        </Link>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                    <div className="mb-6 flex items-center justify-between gap-3">
+                      <h3 className="text-2xl font-bold text-slate-900">카드</h3>
+                      <div className="flex items-center gap-2">
+                        {issuedCards.length > 0 &&
+                          (isShowingAllCardNumbers ? (
+                            <button
+                              type="button"
+                              onClick={handleHideAllCardNumbers}
+                              className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                            >
+                              카드번호 숨기기
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={handleOpenRevealForm}
+                              className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                            >
+                              전체 번호 보기
+                            </button>
+                          ))}
+                        <Link
+                          to="/card/history"
+                          className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                        >
+                          카드 내역
+                        </Link>
+                      </div>
+                    </div>
+
+                    {issuedCards.length > 0 ? (
+                      <div className="space-y-4">
+                        {!isShowingAllCardNumbers && isRevealFormOpen && (
+                          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+                            <p className="text-sm font-medium text-slate-700">
+                              계정 비밀번호를 입력하면 카드번호를 볼 수 있습니다.
+                            </p>
+                            <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+                              <input
+                                type="password"
+                                autoComplete="current-password"
+                                value={accountPasswordInput}
+                                onChange={(event) => setAccountPasswordInput(event.target.value)}
+                                className="h-11 rounded-xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 sm:w-44"
+                                placeholder="계정 비밀번호"
+                              />
+                              <button
+                                type="button"
+                                onClick={handleConfirmReveal}
+                                disabled={isVerifyingPassword}
+                                className="rounded-xl bg-[#6d8ca6] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#5c7c97] disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {isVerifyingPassword ? "확인 중" : "확인"}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={handleHideAllCardNumbers}
+                                className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                              >
+                                취소
+                              </button>
+                            </div>
+                            {accountPasswordError && (
+                              <p className="mt-3 text-sm text-rose-600">{accountPasswordError}</p>
+                            )}
+                          </div>
+                        )}
+
+                        {issuedCards.map((account) => (
+                          <div
+                            key={account.cardId}
+                            className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-3"
+                          >
+                            <p className="text-base font-semibold text-slate-900">{account.accountName}</p>
+                            <p className="mt-1 text-sm text-slate-500">
+                              {isShowingAllCardNumbers
+                                ? account.cardNumber ?? "미발급"
+                                : maskCardNumber(account.cardNumber)}
+                            </p>
+                            <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                              <div>
+                                <p className="text-slate-500">카드 상태</p>
+                                <p className="mt-1 font-semibold text-slate-900">
+                                  {account.cardStatus ?? "확인 필요"}
+                                </p>
+                              </div>
+                              <div>
+                                <p className="text-slate-500">이번 달 사용액</p>
+                                <p className="mt-1 font-semibold text-slate-900">
+                                  {formatAmount(account.spentThisMonth)}
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-5 py-6">
+                        <p className="text-sm text-slate-500">현재 발급된 카드가 없습니다.</p>
+                        <Link
+                          to="/card/ddokgae"
+                          className="mt-4 inline-flex rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#5c7c97]"
+                        >
+                          카드 신청하러 가기
+                        </Link>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <button
+                type="button"
+                onClick={() => setIsQuickMenuOpen((prev) => !prev)}
+                className="flex w-full items-center justify-between gap-4 text-left"
+              >
+                <h2 className="text-2xl font-bold text-slate-900">자주 가는 메뉴</h2>
+                <span className={sectionToggleClass}>
+                  {isQuickMenuOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                </span>
+              </button>
+              {isQuickMenuOpen && (
+                <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                  {quickMenus.map(({ title, description, icon: Icon, to }) => (
+                    <Link
+                      key={title}
+                      to={to}
+                      className="rounded-2xl border border-slate-100 bg-slate-50/80 p-5 transition hover:border-slate-200 hover:bg-white"
+                    >
+                      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+                        <Icon className="h-6 w-6" />
+                      </div>
+                      <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-slate-500">{description}</p>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
           </div>
-        </section>
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/pages/card/DdokgaeCard.tsx
+++ b/src/app/pages/card/DdokgaeCard.tsx
@@ -49,6 +49,10 @@ type CardPreview = {
   cardHolderName: string;
 };
 
+type MyProfile = {
+  name: string;
+};
+
 const DEFAULT_CARD_PREVIEW: CardPreview = {
   cardNumber: "1234 5678 9012 3456",
   expiredYm: "03/29",
@@ -89,6 +93,7 @@ export default function DdokgaeCard() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [issueResult, setIssueResult] = useState<CardIssueResponse | null>(null);
   const [cardPreview, setCardPreview] = useState<CardPreview>(DEFAULT_CARD_PREVIEW);
+  const [currentUserName, setCurrentUserName] = useState(DEFAULT_CARD_PREVIEW.cardHolderName);
 
   useEffect(() => {
     let isMounted = true;
@@ -100,14 +105,25 @@ export default function DdokgaeCard() {
       }
 
       try {
-        const response = await getJson<CardHistoryResponse>("/api/cards/history");
+        const [profile, response] = await Promise.all([
+          getJson<MyProfile>("/api/auth/me"),
+          getJson<CardHistoryResponse>("/api/cards/history"),
+        ]);
         if (!isMounted) {
           return;
         }
 
+        const resolvedUserName = profile.name?.trim()
+          ? profile.name.toUpperCase()
+          : DEFAULT_CARD_PREVIEW.cardHolderName;
+        setCurrentUserName(resolvedUserName);
+
         const ownedCards = response.accounts.filter((account) => account.cardId && account.cardNumber);
         if (ownedCards.length === 0) {
-          setCardPreview(DEFAULT_CARD_PREVIEW);
+          setCardPreview({
+            ...DEFAULT_CARD_PREVIEW,
+            cardHolderName: resolvedUserName,
+          });
           return;
         }
 
@@ -115,10 +131,11 @@ export default function DdokgaeCard() {
         setCardPreview({
           cardNumber: formatPreviewCardNumber(randomCard.cardNumber),
           expiredYm: formatPreviewExpiredYm(randomCard.expiredYm),
-          cardHolderName: (randomCard.accountName || DEFAULT_CARD_PREVIEW.cardHolderName).toUpperCase(),
+          cardHolderName: resolvedUserName,
         });
       } catch {
         if (isMounted) {
+          setCurrentUserName(DEFAULT_CARD_PREVIEW.cardHolderName);
           setCardPreview(DEFAULT_CARD_PREVIEW);
         }
       }
@@ -182,7 +199,7 @@ export default function DdokgaeCard() {
       setCardPreview({
         cardNumber: formatPreviewCardNumber(response.cardNumber),
         expiredYm: formatPreviewExpiredYm(response.expiredYm),
-        cardHolderName: (response.accountName || accountName || DEFAULT_CARD_PREVIEW.cardHolderName).toUpperCase(),
+        cardHolderName: currentUserName,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : "REQUEST_FAILED";


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #42 

---

### 📝 작업 내용
- 마이페이지 UI 구현, 헤더 반응형 전환 시점, 카드홀더 표기 조정

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 마이페이지에 실제 프로필·계좌·대출 데이터를 불러와 표시
  * 비밀번호 인증 기반 카드번호 공개 흐름 추가
  * 페이지 내 섹션별 접기/펼치기(콜랩서블) UI 도입 및 로딩/오류 뷰 제공

* **개선 사항**
  * 카드 미리보기에 사용자 프로필에서 가져온 소유자명 반영
  * 헤더 반응형 동작 최적화(대응 브레이크포인트 및 메뉴 동기화)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->