### PR TITLE
Feat: API 연동: sendMessage 함수 호출 시 기존에 누락되었던 sessionId를 함께 보내도록 수정

### DIFF
--- a/src/app/api/chat.ts
+++ b/src/app/api/chat.ts
@@ -2,6 +2,7 @@ export interface ChatRequest {
   user_id: string;
   message: string;
   user_info: Record<string, any>;
+  session_id?: string;
 }
 
 export interface ChatResponse {
@@ -12,16 +13,19 @@ export async function sendMessage(
   userId: string,
   message: string,
   onChunk: (chunk: string) => void,
-): Promise<void> {
+  sessionId?: string,
+): Promise<string | null> {
   const response = await fetch("/api/chat", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
+    credentials: "include",
     body: JSON.stringify({
       user_id: userId,
       message,
       user_info: {},
+      session_id: sessionId,
     } as ChatRequest),
   });
 
@@ -36,6 +40,7 @@ export async function sendMessage(
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8");
+  const nextSessionId = response.headers.get("X-Chat-Session-Id");
 
   while (true) {
     const { done, value } = await reader.read();
@@ -52,4 +57,6 @@ export async function sendMessage(
   if (lastChunk) {
     onChunk(lastChunk);
   }
+
+  return nextSessionId;
 }

--- a/src/app/components/ChatBot.tsx
+++ b/src/app/components/ChatBot.tsx
@@ -11,6 +11,7 @@ export default function ChatBot() {
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(() => sessionStorage.getItem("chat_session_id"));
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const bufferRef = useRef<string>("");
@@ -23,7 +24,7 @@ export default function ChatBot() {
 
     return [
       {
-        text: "안녕하세요! 넛지뱅크 AI 상담사입니다. 무엇을 도와드릴까요?",
+        text: "안녕하세요! \nNUDGEBANK 금융 상담 AI입니다. \n무엇을 도와드릴까요?",
         sender: "bot",
       },
     ];
@@ -32,6 +33,14 @@ export default function ChatBot() {
   useEffect(() => {
     sessionStorage.setItem("chat_history", JSON.stringify(messages));
   }, [messages]);
+
+  useEffect(() => {
+    if (sessionId) {
+      sessionStorage.setItem("chat_session_id", sessionId);
+      return;
+    }
+    sessionStorage.removeItem("chat_session_id");
+  }, [sessionId]);
 
   useEffect(() => {
     if (isOpen) {
@@ -117,9 +126,13 @@ export default function ChatBot() {
     startTypingEffect();
 
     try {
-      await sendMessage("user-123", userMessage, (chunk) => {
+      const nextSessionId = await sendMessage("user-123", userMessage, (chunk) => {
         bufferRef.current += chunk;
-      });
+      }, sessionId ?? undefined);
+
+      if (nextSessionId) {
+        setSessionId(nextSessionId);
+      }
 
       streamDoneRef.current = true;
     } catch (error) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #50 

---

### 📝 작업 내용
- API 연동: sendMessage 함수 호출 시 기존에 누락되었던 sessionId를 함께 보내도록 수정했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 세션 지속성이 추가되었습니다. 사용자의 대화 이력이 유지되며, 새로운 세션 간에도 연속성이 보장됩니다.
  * 챗봇 인사말 텍스트를 개선하고 브랜딩을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->