### PR TITLE
Feat: 카드 이용내역에 대출 입금 내역 연동

### DIFF
--- a/src/app/pages/card/CardHistory.tsx
+++ b/src/app/pages/card/CardHistory.tsx
@@ -57,6 +57,13 @@ function formatAmount(amount: number) {
   return `${amount.toLocaleString("ko-KR")}\uC6D0`;
 }
 
+function isLoanDisbursementTransaction(transaction: CardHistoryTransaction) {
+  return (
+    transaction.marketName === "NudgeBank 대출 실행" ||
+    transaction.categoryName === "대출"
+  );
+}
+
 function maskCardNumber(cardNumber: string | null) {
   if (!cardNumber) {
     return UI_TEXT.noCardInfo;
@@ -219,11 +226,19 @@ export default function CardHistory() {
             {selectedAccount.transactions.map((transaction) => (
               <div
                 key={transaction.transactionId}
-                className="px-6 py-5 transition-colors hover:bg-slate-50 md:px-8"
+                className={`px-6 py-5 transition-colors hover:bg-slate-50 md:px-8 ${
+                  isLoanDisbursementTransaction(transaction) ? "bg-emerald-50/50" : ""
+                }`}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex min-w-0 items-start gap-4">
-                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-blue-100 bg-blue-50 text-blue-500">
+                    <div
+                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border ${
+                        isLoanDisbursementTransaction(transaction)
+                          ? "border-emerald-100 bg-emerald-50 text-emerald-600"
+                          : "border-blue-100 bg-blue-50 text-blue-500"
+                      }`}
+                    >
                       <Receipt className="h-5 w-5" />
                     </div>
 
@@ -231,12 +246,24 @@ export default function CardHistory() {
                       <p className="truncate text-base font-semibold text-slate-900">
                         {transaction.marketName}
                       </p>
+                      <p className="mt-1 text-xs font-medium text-slate-500">
+                        {isLoanDisbursementTransaction(transaction)
+                          ? "대출 실행 입금"
+                          : transaction.categoryName}
+                      </p>
                       <p className="mt-1 text-xs text-slate-400">{transaction.transactionDatetime}</p>
                     </div>
                   </div>
 
                   <div className="shrink-0 text-right">
-                    <p className="text-lg font-bold text-slate-900 md:text-xl">
+                    <p
+                      className={`text-lg font-bold md:text-xl ${
+                        isLoanDisbursementTransaction(transaction)
+                          ? "text-emerald-600"
+                          : "text-slate-900"
+                      }`}
+                    >
+                      {isLoanDisbursementTransaction(transaction) ? "+" : ""}
                       {formatAmount(transaction.amount)}
                     </p>
                   </div>

--- a/src/app/pages/card/CardHistory.tsx
+++ b/src/app/pages/card/CardHistory.tsx
@@ -226,8 +226,10 @@ export default function CardHistory() {
             {selectedAccount.transactions.map((transaction) => (
               <div
                 key={transaction.transactionId}
-                className={`px-6 py-5 transition-colors hover:bg-slate-50 md:px-8 ${
-                  isLoanDisbursementTransaction(transaction) ? "bg-emerald-50/50" : ""
+                className={`px-6 py-5 transition-colors md:px-8 ${
+                  isLoanDisbursementTransaction(transaction)
+                    ? "bg-emerald-50/50 hover:bg-emerald-50"
+                    : "hover:bg-slate-50"
                 }`}
               >
                 <div className="flex items-start justify-between gap-4">
@@ -263,8 +265,12 @@ export default function CardHistory() {
                           : "text-slate-900"
                       }`}
                     >
-                      {isLoanDisbursementTransaction(transaction) ? "+" : ""}
-                      {formatAmount(transaction.amount)}
+                      {isLoanDisbursementTransaction(transaction) && transaction.amount > 0 ? "+" : ""}
+                      {formatAmount(
+                        isLoanDisbursementTransaction(transaction)
+                          ? Math.abs(transaction.amount)
+                          : transaction.amount,
+                      )}
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #48 

---

### 📝 작업 내용
- 카드 이용내역 화면에서 대출 실행 거래를 입금 내역으로 식별하도록 UI를 보완
- 대출 실행 거래를 일반 결제 내역과 구분되도록 색상과 라벨을 추가
- 대출 실행 금액이 `+금액` 형태로 표시되도록 거래 렌더링을 수정

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대출 실행 거래에 초록(에메랄드) 테마의 행 및 호버 강조를 적용했습니다.
  * 거래 항목의 아이콘 테두리/배경/텍스트 색상을 대출 실행시 에메랄드 계열로 변경했습니다.
  * 대출 실행 거래에 "대출 실행 입금" 보조 라벨을 표시하도록 했습니다.
  * 대출 실행 거래 금액은 절대값으로 표시하고 앞에 "+" 기호를 추가해 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->