### PR TITLE
Feat: 대출 상태 및 카드 이용내역 표시 개선

### DIFF
--- a/src/app/pages/card/CardHistory.tsx
+++ b/src/app/pages/card/CardHistory.tsx
@@ -262,15 +262,11 @@ export default function CardHistory() {
                       className={`text-lg font-bold md:text-xl ${
                         isLoanDisbursementTransaction(transaction)
                           ? "text-emerald-600"
-                          : "text-slate-900"
+                          : "text-rose-600"
                       }`}
                     >
-                      {isLoanDisbursementTransaction(transaction) && transaction.amount > 0 ? "+" : ""}
-                      {formatAmount(
-                        isLoanDisbursementTransaction(transaction)
-                          ? Math.abs(transaction.amount)
-                          : transaction.amount,
-                      )}
+                      {isLoanDisbursementTransaction(transaction) ? "+" : "-"}
+                      {formatAmount(Math.abs(transaction.amount))}
                     </p>
                   </div>
                 </div>

--- a/src/app/pages/loan/LoanDetail.tsx
+++ b/src/app/pages/loan/LoanDetail.tsx
@@ -133,10 +133,6 @@ const tabs: { id: DetailTab; label: string }[] = [
 ];
 
 function getApplicationStatusLabel(application: LoanApplicationSummary) {
-  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
-    return "서류 제출 완료";
-  }
-
   switch (application.applicationStatus) {
     case "DOCUMENT_REQUIRED":
       return "서류 제출 필요";

--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -28,10 +28,6 @@ type LoanApplicationSummary = {
 };
 
 function getApplicationStatusLabel(application: LoanApplicationSummary) {
-  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
-    return "서류 제출 완료";
-  }
-
   switch (application.applicationStatus) {
     case "DOCUMENT_REQUIRED":
       return "서류 제출 필요";

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -89,10 +89,6 @@ const failureReasonMessages: Record<string, string> = {
 };
 
 function getApplicationStatusLabel(application: LoanApplicationSummary) {
-  if (application.productKey === "youth-loan" && application.certificateSubmitted) {
-    return "서류 제출 완료";
-  }
-
   switch (application.applicationStatus) {
     case "DOCUMENT_REQUIRED":
       return "서류 제출 필요";


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #53 

---

### 📝 작업 내용
- 대출 상품/상세/관리 화면에서 신청 상태가 현재 서비스 흐름에 맞게 `이용 중` 중심으로 표시되도록 정리
- 자기계발 대출의 OCR 제출 여부가 신청 상태 문구를 덮어쓰지 않도록 상태 표시 로직 수정
- 카드 이용내역에서 대출 실행 거래는 초록색 `+금액`, 일반 결제 거래는 빨간색 `-금액`으로 표시되도록 개선

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 거래 금액 표시 스타일이 개선되었습니다.
* 거래 금액 형식 처리가 간소화되었습니다.

## Refactor
* 대출 신청 상태 레이블 표시 로직이 통일되었습니다.
* 모든 대출 상품에서 일관된 상태 기반 표시가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->