### PR TITLE
Feat: 자기계발 대출 신청 시 카드 및 상환 계좌 선택 연동

### DIFF
--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -51,6 +51,13 @@ type MyLoanSummary = {
   repaymentAccountNumber: string;
 };
 
+type LoanApplicationSummary = {
+  loanApplicationId: number;
+  productKey: string;
+  productName: string;
+  applicationStatus: string;
+};
+
 const quickMenus = [
   {
     title: "회원정보 관리",
@@ -111,6 +118,8 @@ export default function MyPage() {
   const [profile, setProfile] = useState<MyProfile | null>(null);
   const [accounts, setAccounts] = useState<CardHistoryAccount[]>([]);
   const [loanSummary, setLoanSummary] = useState<MyLoanSummary | null>(null);
+  const [loanApplications, setLoanApplications] = useState<LoanApplicationSummary[]>([]);
+  const [selectedProductKey, setSelectedProductKey] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const [isShowingAllCardNumbers, setIsShowingAllCardNumbers] = useState(false);
@@ -132,10 +141,11 @@ export default function MyPage() {
       setErrorMessage("");
 
       try {
-        const [profileResponse, cardHistoryResponse, loanSummaryResponse] = await Promise.all([
+        const [profileResponse, cardHistoryResponse, loanSummaryResponse, loanApplicationsResponse] = await Promise.all([
           getJson<MyProfile>("/api/auth/me"),
           getJson<CardHistoryResponse>("/api/cards/history"),
           getJson<MyLoanSummary>("/api/loans/me/summary").catch(() => null),
+          getJson<LoanApplicationSummary[]>("/api/loan-applications/me").catch(() => []),
         ]);
 
         if (!isMounted) {
@@ -145,6 +155,7 @@ export default function MyPage() {
         setProfile(profileResponse);
         setAccounts(cardHistoryResponse.accounts);
         setLoanSummary(loanSummaryResponse);
+        setLoanApplications(loanApplicationsResponse);
       } catch (error) {
         if (!isMounted) {
           return;
@@ -154,6 +165,7 @@ export default function MyPage() {
         setProfile(null);
         setAccounts([]);
         setLoanSummary(null);
+        setLoanApplications([]);
         setErrorMessage(
           message === "UNAUTHORIZED"
             ? "로그인 후 마이페이지를 확인할 수 있습니다."
@@ -172,6 +184,57 @@ export default function MyPage() {
       isMounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (loanApplications.length === 0) {
+      setSelectedProductKey("");
+      return;
+    }
+
+    if (loanApplications.some((application) => application.productKey === selectedProductKey)) {
+      return;
+    }
+
+    setSelectedProductKey(
+      loanApplications.find((application) => application.productKey === "youth-loan")?.productKey ??
+        loanApplications[0].productKey,
+    );
+  }, [loanApplications, selectedProductKey]);
+
+  useEffect(() => {
+    if (!selectedProductKey) {
+      return;
+    }
+
+    let isMounted = true;
+
+    async function loadLoanSummary() {
+      try {
+        const productQuery = `?productKey=${selectedProductKey}`;
+        const nextLoanSummary = await getJson<MyLoanSummary>(`/api/loans/me/summary${productQuery}`).catch(
+          () => null,
+        );
+
+        if (!isMounted) {
+          return;
+        }
+
+        setLoanSummary(nextLoanSummary);
+      } catch {
+        if (!isMounted) {
+          return;
+        }
+
+        setLoanSummary(null);
+      }
+    }
+
+    void loadLoanSummary();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedProductKey]);
 
   const issuedCards = accounts.filter((account) => account.cardId);
   const totalBalance = accounts.reduce((sum, account) => sum + account.balance, 0);
@@ -334,20 +397,58 @@ export default function MyPage() {
                 </span>
               </button>
               {isLoanOpen && (
-                <div className="mt-6 grid gap-4 md:grid-cols-2">
-                  <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
-                    <p className="text-sm text-slate-500">잔여 원금</p>
-                    <p className="mt-2 text-2xl font-semibold text-slate-900">
-                      {loanSummary ? formatAmount(loanSummary.remainingPrincipal) : "대출 정보 없음"}
-                    </p>
+                <>
+                  {loanApplications.length > 0 && (
+                    <div className="mt-6 flex flex-wrap gap-2">
+                      {loanApplications.map((application) => {
+                        const isSelected = application.productKey === selectedProductKey;
+                        return (
+                          <button
+                            key={application.loanApplicationId}
+                            type="button"
+                            onClick={() => setSelectedProductKey(application.productKey)}
+                            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                              isSelected
+                                ? "bg-sky-600 text-white shadow-sm"
+                                : "border border-slate-200 bg-white text-slate-600 hover:border-sky-200 hover:text-sky-700"
+                            }`}
+                          >
+                            {application.productName}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                  <div className="mt-6 grid gap-4 md:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">잔여 원금</p>
+                      <p className="mt-2 text-2xl font-semibold text-slate-900">
+                        {loanSummary ? formatAmount(loanSummary.remainingPrincipal) : "대출 정보 없음"}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">누적 상환액</p>
+                      <p className="mt-2 text-2xl font-semibold text-slate-900">
+                        {loanSummary ? formatAmount(loanSummary.repaidPrincipal) : "대출 정보 없음"}
+                      </p>
+                    </div>
                   </div>
-                  <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
-                    <p className="text-sm text-slate-500">누적 상환액</p>
-                    <p className="mt-2 text-2xl font-semibold text-slate-900">
-                      {loanSummary ? formatAmount(loanSummary.repaidPrincipal) : "대출 정보 없음"}
-                    </p>
-                  </div>
-                </div>
+                  {loanApplications.length > 0 && (
+                    <div className="mt-4 rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                      <p className="text-sm text-slate-500">신청 상품</p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {loanApplications.map((application) => (
+                          <span
+                            key={application.loanApplicationId}
+                            className="rounded-full border border-sky-100 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700"
+                          >
+                            {application.productName}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
             </section>
 

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, FileText, ShieldCheck } from "lucide-react";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
-import { postJson } from "../../lib/api";
+import { getJson, postJson } from "../../lib/api";
 
 type LoanApplyConfig = {
   name: string;
@@ -35,6 +35,20 @@ type LoanApplicationSummary = {
   appliedAt: string;
   requiresCertificateSubmission: boolean;
   certificateSubmitted: boolean;
+};
+
+type CardHistoryResponse = {
+  ok: boolean;
+  message: string;
+  accounts: CardHistoryAccount[];
+};
+
+type CardHistoryAccount = {
+  accountId: number;
+  accountName: string;
+  accountNumber: string;
+  cardId: number | null;
+  cardNumber: string | null;
 };
 
 const productConfigs: Record<string, LoanApplyConfig> = {
@@ -79,10 +93,41 @@ export default function LoanApply() {
   const [purpose, setPurpose] = useState(product?.defaultPurpose ?? "");
   const [monthlyIncome, setMonthlyIncome] = useState("");
   const [salaryDate, setSalaryDate] = useState("");
+  const [accounts, setAccounts] = useState<CardHistoryAccount[]>([]);
+  const [selectedCardId, setSelectedCardId] = useState<number | "">("");
   const [agreeTerms, setAgreeTerms] = useState(false);
   const [agreePrivacy, setAgreePrivacy] = useState(false);
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadAccounts() {
+      try {
+        const response = await getJson<CardHistoryResponse>("/api/cards/history");
+        if (!isMounted) {
+          return;
+        }
+
+        setAccounts(response.accounts);
+        setSelectedCardId(
+          (current) =>
+            current || response.accounts.find((account) => account.cardId)?.cardId || "",
+        );
+      } catch {
+        if (isMounted) {
+          setAccounts([]);
+        }
+      }
+    }
+
+    void loadAccounts();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   if (!productId || !product) {
     return (
@@ -137,6 +182,11 @@ export default function LoanApply() {
       return;
     }
 
+    if (!selectedCardId) {
+      setError("신청 카드를 선택해 주세요.");
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       await postJson<LoanApplicationSummary>("/api/loan-applications", {
@@ -146,6 +196,7 @@ export default function LoanApply() {
         monthlyIncome: parsedMonthlyIncome,
         salaryDate: parsedSalaryDate,
         purpose,
+        cardId: selectedCardId,
       });
       window.dispatchEvent(new Event("loan-application-change"));
       navigate("/loan/management");
@@ -213,6 +264,24 @@ export default function LoanApply() {
                     {termOption}
                   </option>
                 ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-slate-600">신청 카드</label>
+              <select
+                value={selectedCardId}
+                onChange={(event) => setSelectedCardId(event.target.value ? Number(event.target.value) : "")}
+                className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+              >
+                <option value="">카드를 선택해 주세요</option>
+                {accounts
+                  .filter((account) => account.cardId)
+                  .map((account) => (
+                    <option key={account.cardId} value={account.cardId ?? ""}>
+                      {account.cardNumber ?? "카드 없음"} / {account.accountName}
+                    </option>
+                  ))}
               </select>
             </div>
 

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -167,6 +167,7 @@ export default function MyLoanManagement() {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [ocrResult, setOcrResult] = useState<CertificateSubmissionResponse | null>(null);
   const [certificateId, setCertificateId] = useState("");
+  const [selectedProductKey, setSelectedProductKey] = useState("");
 
   useEffect(() => {
     const syncApplications = async () => {
@@ -218,10 +219,11 @@ export default function MyLoanManagement() {
       setLoanDataError(null);
 
       try {
+        const productQuery = selectedProductKey ? `?productKey=${selectedProductKey}` : "";
         const [nextSummary, nextSchedules, nextHistories] = await Promise.all([
-          getJson<MyLoanSummary>("/api/loans/me/summary"),
-          getJson<MyLoanRepaymentSchedule[]>("/api/loans/me/repayment-schedules"),
-          getJson<MyLoanRepaymentHistory[]>("/api/loans/me/repayment-histories"),
+          getJson<MyLoanSummary>(`/api/loans/me/summary${productQuery}`),
+          getJson<MyLoanRepaymentSchedule[]>(`/api/loans/me/repayment-schedules${productQuery}`),
+          getJson<MyLoanRepaymentHistory[]>(`/api/loans/me/repayment-histories${productQuery}`),
         ]);
 
         if (requestId === loanManagementRequestIdRef.current) {
@@ -255,13 +257,29 @@ export default function MyLoanManagement() {
       window.removeEventListener("loan-application-change", syncLoanManagement);
       window.removeEventListener("storage", handleStorageChange);
     };
-  }, []);
+  }, [selectedProductKey]);
 
   useEffect(() => {
     setSimulationAmount((currentAmount) =>
       normalizeSimulationAmount(currentAmount, summary?.remainingPrincipal ?? 0),
     );
   }, [summary?.remainingPrincipal]);
+
+  useEffect(() => {
+    if (applications.length === 0) {
+      setSelectedProductKey("");
+      return;
+    }
+
+    if (applications.some((application) => application.productKey === selectedProductKey)) {
+      return;
+    }
+
+    setSelectedProductKey(
+      applications.find((application) => application.productKey === "youth-loan")?.productKey ??
+        applications[0].productKey,
+    );
+  }, [applications, selectedProductKey]);
 
   const repaidPrincipal = summary?.repaidPrincipal ?? 0;
   const repaymentProgress =
@@ -318,11 +336,14 @@ export default function MyLoanManagement() {
     0,
   );
 
-  const selfDevelopmentApplication = useMemo(
-    () => applications.find((application) => application.productKey === "youth-loan") ?? null,
-    [applications],
+  const selectedApplication = useMemo(
+    () =>
+      applications.find((application) => application.productKey === selectedProductKey) ??
+      applications[0] ??
+      null,
+    [applications, selectedProductKey],
   );
-  const canSubmitCertificate = !!selfDevelopmentApplication;
+  const canSubmitCertificate = !!selectedApplication?.preferentialRateVerificationAvailable;
 
   const statusText: Record<UploadStatus, string> = {
     idle: "자기계발 대출 신청 후 자격증 파일을 제출할 수 있습니다.",
@@ -341,7 +362,7 @@ export default function MyLoanManagement() {
   };
 
   const handleUpload = async () => {
-    if (!selfDevelopmentApplication || !selectedFile) {
+    if (!selectedApplication || !selectedFile) {
       return;
     }
 
@@ -352,7 +373,7 @@ export default function MyLoanManagement() {
     }
 
     const formData = new FormData();
-    formData.append("loanApplicationId", String(selfDevelopmentApplication.loanApplicationId));
+    formData.append("loanApplicationId", String(selectedApplication.loanApplicationId));
     formData.append("certificateId", certificateId);
     formData.append("file", selectedFile);
 
@@ -534,16 +555,45 @@ export default function MyLoanManagement() {
                 </p>
               </div>
 
+              {applications.length > 0 && (
+                <div className="mb-4 flex flex-wrap gap-2">
+                  {applications.map((application) => {
+                    const isSelected = application.productKey === selectedProductKey;
+                    return (
+                      <button
+                        key={`selector-${application.loanApplicationId}`}
+                        type="button"
+                        onClick={() => setSelectedProductKey(application.productKey)}
+                        className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                          isSelected
+                            ? "bg-sky-600 text-white shadow-sm"
+                            : "border border-slate-200 bg-white text-slate-600 hover:border-sky-200 hover:text-sky-700"
+                        }`}
+                      >
+                        {application.productName}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
               {applications.length > 0 ? (
                 <div className="space-y-4">
                   {applications.map((application) => (
                     <div
                       key={application.loanApplicationId}
-                      className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
+                      className={`rounded-2xl px-4 py-4 ${
+                        application.productKey === selectedProductKey
+                          ? "border border-sky-200 bg-sky-50/80"
+                          : "border border-slate-100 bg-slate-50/80"
+                      }`}
                     >
                       <p className="text-sm text-slate-500">{application.productName}</p>
                       <p className="mt-1 text-sm text-slate-600">
                         상태 <span className="font-semibold text-sky-700">{getReviewStatusLabel(application)}</span>
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        신청일 {application.appliedAt.slice(0, 10)}
                       </p>
                     </div>
                   ))}
@@ -698,7 +748,7 @@ export default function MyLoanManagement() {
             </div>
           )}
 
-          {selfDevelopmentApplication && (
+          {selectedApplication?.preferentialRateVerificationAvailable && (
             <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
               <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
                 <div>
@@ -716,19 +766,19 @@ export default function MyLoanManagement() {
                   <p>
                     신청 상품{" "}
                     <span className="font-semibold text-slate-900">
-                      {selfDevelopmentApplication.productName}
+                      {selectedApplication.productName}
                     </span>
                   </p>
                   <p className="mt-1">
                     상태{" "}
                     <span className="font-semibold text-sky-700">
-                      {getReviewStatusLabel(selfDevelopmentApplication)}
+                      {getReviewStatusLabel(selectedApplication)}
                     </span>
                   </p>
                   <p className="mt-1">
                     인증 상태{" "}
                     <span className="font-semibold text-sky-700">
-                      {getPreferentialRateStatusLabel(selfDevelopmentApplication)}
+                      {getPreferentialRateStatusLabel(selectedApplication)}
                     </span>
                   </p>
                 </div>
@@ -755,7 +805,7 @@ export default function MyLoanManagement() {
                     </div>
                   </div>
 
-                  {selfDevelopmentApplication.preferentialRateVerificationSubmitted && (
+                  {selectedApplication.preferentialRateVerificationSubmitted && (
                     <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50/70 px-4 py-4">
                       <p className="text-sm font-semibold text-emerald-700">서류 제출 완료</p>
                       <p className="mt-2 text-sm text-slate-600">


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #64 

---

### 📝 작업 내용
- 대출 신청 화면에서 사용자가 신청 카드를 선택할 수 있도록 UI 및 요청 연동 추가
- 내 대출 관리 화면에서 신청한 상품 목록을 기준으로 상품별 전환이 가능하도록 보완
- 마이페이지 대출 영역에서도 신청 상품 선택에 따라 해당 상품의 대출 요약이 보이도록 수정
- 자기계발 대출 선택 시 OCR 제출 영역이 해당 상품 기준으로만 노출되도록 정리

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 내 계정 페이지에서 대출 상품을 선택하여 상품별 대출 잔액 및 상환액 조회 가능
  * 대출 신청 시 적용할 카드를 선택할 수 있는 기능 추가
  * 대출 관리 페이지에서 상품별 필터링을 통해 상환 일정 및 이력 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->