### PR TITLE
Feat: 소비분석대출 신청폼 보호잔액 입력 추가

### DIFF
--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -253,7 +253,7 @@ export default function MyPage() {
     ? "상환 방식 정보 없음"
     : loanSummary.repaymentType === "MATURITY_LUMP_SUM"
       ? "만기일시상환"
-      : "원리금 분할 상환";
+      : "원리금균등분할상환";
 
   const handleOpenRevealForm = () => {
     setIsRevealFormOpen(true);

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -85,6 +85,7 @@ export default function LoanApply() {
   const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
   const product = productId ? productConfigs[productId] : undefined;
+  const requiresProtectedBalance = productId === "consumption-loan";
   const [amount, setAmount] = useState(product?.defaultAmount ?? "");
   const termOptions = productId ? termOptionsByProduct[productId] ?? ["12개월"] : ["12개월"];
   const amountRange =
@@ -93,6 +94,7 @@ export default function LoanApply() {
   const [purpose, setPurpose] = useState(product?.defaultPurpose ?? "");
   const [monthlyIncome, setMonthlyIncome] = useState("");
   const [salaryDate, setSalaryDate] = useState("");
+  const [protectedBalance, setProtectedBalance] = useState("");
   const [accounts, setAccounts] = useState<CardHistoryAccount[]>([]);
   const [selectedCardId, setSelectedCardId] = useState<number | "">("");
   const [agreeTerms, setAgreeTerms] = useState(false);
@@ -161,6 +163,7 @@ export default function LoanApply() {
     const parsedAmount = Number(amount);
     const parsedMonthlyIncome = Number(monthlyIncome);
     const parsedSalaryDate = Number(salaryDate);
+    const parsedProtectedBalance = requiresProtectedBalance ? Number(protectedBalance) : 0;
 
     if (Number.isNaN(parsedAmount) || parsedAmount < amountRange.min || parsedAmount > amountRange.max) {
       setError(`신청 금액은 ${amountRange.min.toLocaleString("ko-KR")}원~${amountRange.max.toLocaleString("ko-KR")}원 범위로 입력해 주세요.`);
@@ -182,6 +185,11 @@ export default function LoanApply() {
       return;
     }
 
+    if (requiresProtectedBalance && (Number.isNaN(parsedProtectedBalance) || parsedProtectedBalance < 0)) {
+      setError("보호잔액은 0원 이상으로 입력해 주세요.");
+      return;
+    }
+
     if (!selectedCardId) {
       setError("신청 카드를 선택해 주세요.");
       return;
@@ -192,6 +200,7 @@ export default function LoanApply() {
       await postJson<LoanApplicationSummary>("/api/loan-applications", {
         productKey: productId,
         loanAmount: parsedAmount,
+        protectedBalance: parsedProtectedBalance,
         loanTerm,
         monthlyIncome: parsedMonthlyIncome,
         salaryDate: parsedSalaryDate,
@@ -305,6 +314,21 @@ export default function LoanApply() {
                 />
               </div>
             </div>
+
+            {requiresProtectedBalance && (
+              <div>
+                <label className="mb-2 block text-sm font-medium text-slate-600">최소 생활비</label>
+                <input
+                  value={protectedBalance}
+                  onChange={(event) => setProtectedBalance(event.target.value)}
+                  className="h-12 w-full rounded-2xl border border-slate-200 px-4 text-sm text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+                  placeholder="상환에서 제외할 최소 생활비를 입력해 주세요"
+                />
+                <p className="mt-2 text-sm leading-6 text-slate-500">
+                  입력한 금액은 보호잔액으로 저장되며, 계좌 잔액에서 제외한 나머지 금액만 상환 가능 금액으로 계산됩니다.
+                </p>
+              </div>
+            )}
 
             <div>
               <label className="mb-2 block text-sm font-medium text-slate-600">신청 목적</label>

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -396,7 +396,7 @@ export default function MyLoanManagement() {
     ? "상환 방식 정보 없음"
     : summary.repaymentType === "MATURITY_LUMP_SUM"
       ? "만기일시상환"
-      : "원리금 분할 상환";
+      : "원리금균등분할상환";
   const repaymentMethodDescription = !summary
     ? "대출 요약 정보가 준비되면 상환 방식을 확인할 수 있습니다."
     : summary.repaymentType === "MATURITY_LUMP_SUM"


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #70 

---

### 📝 작업 내용
- 소비분석대출 신청 시 상환 가능 금액 계산에 필요한 보호잔액(최소생활비)을 사용자에게 입력받도록 함

---

### 📷 스크린샷 (선택)
- <img width="384" height="401" alt="image" src="https://github.com/user-attachments/assets/a667939f-59e7-4540-a3ca-93ee39b40b4c" />

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 마이페이지 및 대출 관리 화면의 상환 방식 표시 레이블을 올바른 한국어 표기로 정정

* **새로운 기능**
  * 소비자 대출 신청 시 최소 생활비(보호금액) 입력 항목 추가 및 필수 여부에 따른 클라이언트 유효성 검사 적용, 제출 시 값 포함되어 전송
<!-- end of auto-generated comment: release notes by coderabbit.ai -->