### PR TITLE
Feat: 대출 신청 안내 페이지 구현

### DIFF
--- a/src/app/components/ChatBot.tsx
+++ b/src/app/components/ChatBot.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { MessageCircle, X, Send } from "lucide-react";
+import { useNavigate } from "react-router";
 import { sendMessage } from "../api/chat";
 
 type Message = {
@@ -8,6 +9,7 @@ type Message = {
 };
 
 export default function ChatBot() {
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -143,6 +145,18 @@ export default function ChatBot() {
     }
   };
 
+  const handleMoveToGuide = () => {
+    // 챗봇 UI에서 대출 신청 안내 페이지로 이동
+    setIsOpen(false);
+    navigate("/loan/apply-guide");
+  };
+
+  const handleMoveToChatHistory = () => {
+    // 챗봇 UI에서 전체 상담 화면으로 이동
+    setIsOpen(false);
+    navigate("/help/chat-history");
+  };
+
   return (
     <>
       <button
@@ -155,7 +169,7 @@ export default function ChatBot() {
       </button>
 
       {isOpen && (
-        <div className="fixed bottom-8 right-8 w-96 h-[500px] bg-white/95 backdrop-blur-md rounded-lg shadow-2xl flex flex-col z-50 border border-white/20">
+        <div className="fixed bottom-8 right-8 z-50 flex h-[560px] w-96 flex-col rounded-lg border border-white/20 bg-white/95 shadow-2xl backdrop-blur-md">
           <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4 rounded-t-lg flex items-center justify-between">
             <div className="flex items-center gap-2">
               <MessageCircle className="w-5 h-5" />
@@ -169,13 +183,29 @@ export default function ChatBot() {
             </button>
           </div>
 
+          {/* 버튼 3개로 변경 필요 */}
+          <div className="flex gap-2 border-b border-slate-200 bg-slate-50 px-4 py-3">
+            <button
+              type="button"
+              onClick={handleMoveToGuide}
+              className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+            >
+              대출 신청 안내
+            </button>
+            <button
+              type="button"
+              onClick={handleMoveToChatHistory}
+              className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+            >
+              상담 기록 보기
+            </button>
+          </div>
+
           <div className="flex-1 overflow-y-auto p-4 space-y-3">
             {messages.map((message, index) => (
               <div
                 key={index}
-                className={`flex ${
-                  message.sender === "user" ? "justify-end" : "justify-start"
-                }`}
+                className={`flex ${message.sender === "user" ? "justify-end" : "justify-start"}`}
               >
                 <div
                   className={`max-w-[80%] px-4 py-2 rounded-lg whitespace-pre-wrap ${

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -34,7 +34,8 @@ const menuItems: MenuItem[] = [
     label: "대출",
     description: "맞춤형 대출 상품과 대출 관리, 신용 평가 정보를 확인할 수 있습니다.",
     submenu: [
-      { label: "대출상품", path: "/loan/products" },
+      { label: "대출 상품", path: "/loan/products" },
+      { label: "대출 신청 안내", path: "/loan/apply-guide" },
       { label: "대출 관리", path: "/loan/management" },
       { label: "신용 평가", path: "/loan/credit-score" },
     ],
@@ -146,7 +147,9 @@ export default function Header() {
                           aria-expanded={activeMenuLabel === item.label}
                           onFocus={() => setActiveMenuLabel(item.label)}
                           onClick={() =>
-                            setActiveMenuLabel((current) => (current === item.label ? null : item.label))
+                            setActiveMenuLabel((current) =>
+                              current === item.label ? null : item.label,
+                            )
                           }
                           className="whitespace-nowrap py-2 text-sm font-semibold tracking-tight text-white/90 transition-colors hover:text-white md:text-base"
                         >
@@ -216,7 +219,11 @@ export default function Header() {
                   aria-label="메뉴 열기"
                   aria-expanded={isMobileMenuOpen}
                 >
-                  {isMobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+                  {isMobileMenuOpen ? (
+                    <X className="h-5 w-5" />
+                  ) : (
+                    <Menu className="h-5 w-5" />
+                  )}
                 </button>
               </div>
             </div>

--- a/src/app/pages/loan/LoanApplicationGuide.tsx
+++ b/src/app/pages/loan/LoanApplicationGuide.tsx
@@ -1,0 +1,145 @@
+import { ArrowRight, CheckCircle2, FileText, MessageCircle, ShieldCheck } from "lucide-react";
+import { Link } from "react-router";
+
+const guideSteps = [
+  {
+    title: "상품 선택",
+    description: "대출 상품 목록에서 본인 상황에 맞는 상품을 선택하고 주요 조건을 비교합니다.",
+  },
+  {
+    title: "신청 조건 확인",
+    description: "한도, 금리, 상환 기간, 신청 대상과 같은 핵심 조건을 먼저 확인합니다.",
+  },
+  {
+    title: "정보 및 서류 준비",
+    description: "소득 정보, 본인 확인 정보, 필요한 경우 증빙 서류를 준비합니다.",
+  },
+  {
+    title: "심사 및 결과 확인",
+    description: "신청 후 심사 상태와 결과는 대출 관리 화면 또는 상담을 통해 확인합니다.",
+  },
+];
+
+const requiredItems = [
+  "본인 확인 정보",
+  "소득 관련 정보",
+  "상환 계획 확인",
+  "상품별 추가 증빙 서류",
+];
+
+const notices = [
+  "본 페이지는 안내용 화면이며 실제 신청은 이 화면에서 처리되지 않습니다.",
+  "상품별 실제 승인 여부와 조건은 심사 결과에 따라 달라질 수 있습니다.",
+  "추가 서류 제출이 필요한 경우 별도 안내가 제공될 수 있습니다.",
+];
+
+export default function LoanApplicationGuide() {
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,_#f4f8ff_0%,_#f8fbff_30%,_#ffffff_100%)]">
+      <div className="mx-auto max-w-7xl px-4 py-12">
+        <section className="rounded-[32px] border border-slate-200 bg-white px-6 py-8 shadow-[0_20px_60px_rgba(15,23,42,0.08)] md:px-10 md:py-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-blue-500">
+            Loan Guide
+          </p>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 md:text-5xl">
+            대출 신청 안내
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-600 md:text-lg">
+            대출 신청 전에 필요한 절차와 준비 사항을 한 번에 확인할 수 있는 안내 화면입니다.
+            실제 신청은 별도 상품 페이지에서 진행하고, 이 페이지는 화면상 안내만 제공합니다.
+          </p>
+
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link
+              to="/loan/products"
+              className="inline-flex items-center justify-center rounded-2xl bg-[#2a4b78] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#223f64]"
+            >
+              대출 상품 보러가기
+            </Link>
+            {/* 챗봇 상담 화면과 연결 */}
+            <Link
+              to="/help/chat-history"
+              className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-6 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100"
+            >
+              <MessageCircle className="h-4 w-4" />
+              챗봇으로 문의하기
+            </Link>
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-6 lg:grid-cols-[1.4fr_0.8fr]">
+          <div className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_18px_50px_rgba(15,23,42,0.06)] md:p-8">
+            <div className="flex items-center gap-3">
+              <div className="rounded-2xl bg-blue-50 p-3 text-blue-600">
+                <CheckCircle2 className="h-5 w-5" />
+              </div>
+              <h2 className="text-2xl font-bold text-slate-900">신청 절차</h2>
+            </div>
+
+            <div className="mt-8 space-y-4">
+              {guideSteps.map((step, index) => (
+                <div
+                  key={step.title}
+                  className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#2a4b78] text-sm font-bold text-white">
+                      {index + 1}
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">{step.description}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_18px_50px_rgba(15,23,42,0.06)]">
+              <div className="flex items-center gap-3">
+                <div className="rounded-2xl bg-emerald-50 p-3 text-emerald-600">
+                  <FileText className="h-5 w-5" />
+                </div>
+                <h2 className="text-xl font-bold text-slate-900">준비 항목</h2>
+              </div>
+
+              <div className="mt-5 space-y-3">
+                {requiredItems.map((item) => (
+                  <div
+                    key={item}
+                    className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
+                  >
+                    <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_18px_50px_rgba(15,23,42,0.06)]">
+              <div className="flex items-center gap-3">
+                <div className="rounded-2xl bg-amber-50 p-3 text-amber-600">
+                  <ShieldCheck className="h-5 w-5" />
+                </div>
+                <h2 className="text-xl font-bold text-slate-900">유의 사항</h2>
+              </div>
+
+              <ul className="mt-5 space-y-3">
+                {notices.map((notice) => (
+                  <li
+                    key={notice}
+                    className="rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm leading-6 text-slate-700"
+                  >
+                    {notice}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -15,6 +15,7 @@ import CardHistory from "./pages/card/CardHistory";
 import SpendingAnalysis from "./pages/card/SpendingAnalysis";
 import MyPage from "./pages/account/MyPage";
 import ChatHistory from "./pages/help/ChatHistory";
+import LoanApplicationGuide from "./pages/loan/LoanApplicationGuide";
 
 
 export const router = createBrowserRouter([
@@ -28,6 +29,7 @@ export const router = createBrowserRouter([
       { path: "account/my", Component: MyAccount },
       { path: "account/ddokgae", Component: DdokgaeAccount },
       { path: "loan/products", Component: LoanProducts },
+      { path: "loan/apply-guide", Component: LoanApplicationGuide },
       { path: "loan/products/:productId", Component: LoanDetail },
       { path: "loan/products/:productId/apply", Component: LoanApply },
       { path: "loan/management", Component: MyLoanManagement },


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #82 

---

### 📝 작업 내용
- 대출 신청 안내 페이지 구현
- 챗봇 채팅 내 버튼과 연결 필요

---

### 📷 스크린샷 (선택)
![대출 신청 안내 페이지](https://github.com/user-attachments/assets/3bfada86-da73-4578-995c-aa5e8c09804f)


---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 대출 신청 안내 페이지 신규 추가
  * 채팅 위젯에서 대출 신청 안내 및 상담 기록 페이지로 바로 이동 가능한 버튼 추가
  * 헤더 네비게이션 메뉴에 "대출 신청 안내" 메뉴 항목 신규 추가
  * 신청 절차, 준비 항목, 유의 사항 등 대출 신청 관련 안내 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->