### PR TITLE
Refactor: 똑개카드 페이지 카드 선택해서보기, 예적금 관리 페이지 내역 한번에 5개 표기 및 페이지 방식 반영

### DIFF
--- a/src/app/pages/account/DepositManagement.tsx
+++ b/src/app/pages/account/DepositManagement.tsx
@@ -277,10 +277,14 @@ export default function DepositManagement() {
       nextAccounts.find((account) => account.depositAccountId === targetId)?.depositAccountId ??
       nextAccounts[0]?.depositAccountId ??
       null;
+    const selectedIndex = nextSelectedId == null
+      ? -1
+      : nextAccounts.findIndex((account) => account.depositAccountId === nextSelectedId);
+    const nextPage = selectedIndex >= 0 ? Math.floor(selectedIndex / pageSize) + 1 : 1;
 
     setAccounts(nextAccounts);
     setSelectedId(nextSelectedId);
-    setAccountPage(1);
+    setAccountPage(nextPage);
 
     if (nextSelectedId == null) {
       setDetail(null);

--- a/src/app/pages/account/DepositManagement.tsx
+++ b/src/app/pages/account/DepositManagement.tsx
@@ -167,6 +167,8 @@ export default function DepositManagement() {
   const [actionError, setActionError] = useState("");
   const [isPaying, setIsPaying] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const [accountPage, setAccountPage] = useState(1);
+  const pageSize = 5;
 
   const selectedSummary = useMemo(
     () => accounts.find((account) => account.depositAccountId === selectedId) ?? null,
@@ -180,6 +182,15 @@ export default function DepositManagement() {
 
     return detail.schedules.find((schedule) => !schedule.isPaid) ?? null;
   }, [detail]);
+
+  const pagedAccounts = useMemo(() => {
+    const totalPages = Math.max(1, Math.ceil(accounts.length / pageSize));
+    const currentPage = Math.min(accountPage, totalPages);
+    const startIndex = (currentPage - 1) * pageSize;
+    return accounts.slice(startIndex, startIndex + pageSize);
+  }, [accounts, accountPage]);
+
+  const accountTotalPages = useMemo(() => Math.max(1, Math.ceil(accounts.length / pageSize)), [accounts]);
 
   useEffect(() => {
     let isMounted = true;
@@ -269,6 +280,7 @@ export default function DepositManagement() {
 
     setAccounts(nextAccounts);
     setSelectedId(nextSelectedId);
+    setAccountPage(1);
 
     if (nextSelectedId == null) {
       setDetail(null);
@@ -402,7 +414,7 @@ export default function DepositManagement() {
       ) : (
         <div className="grid gap-6 xl:grid-cols-[minmax(320px,0.9fr)_minmax(0,1.4fr)]">
           <aside className="space-y-4">
-            {accounts.map((account) => {
+            {pagedAccounts.map((account) => {
               const isSelected = account.depositAccountId === selectedId;
               const Icon = account.depositProductType === "FIXED_DEPOSIT" ? Landmark : PiggyBank;
 
@@ -452,6 +464,29 @@ export default function DepositManagement() {
                 </button>
               );
             })}
+            {accounts.length > pageSize && (
+              <div className="flex items-center justify-between gap-3 rounded-[28px] border border-slate-200 bg-white px-5 py-4 shadow-[0_20px_50px_rgba(15,23,42,0.06)]">
+                <button
+                  type="button"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={accountPage <= 1}
+                  onClick={() => setAccountPage((current) => Math.max(1, current - 1))}
+                >
+                  이전
+                </button>
+                <span className="text-sm font-medium text-slate-500">
+                  {accountPage} / {accountTotalPages}
+                </span>
+                <button
+                  type="button"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={accountPage >= accountTotalPages}
+                  onClick={() => setAccountPage((current) => Math.min(accountTotalPages, current + 1))}
+                >
+                  다음
+                </button>
+              </div>
+            )}
           </aside>
 
           <section className="rounded-[32px] border border-slate-200 bg-white p-8 shadow-[0_20px_50px_rgba(15,23,42,0.06)]">

--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -1,4 +1,4 @@
-import { BadgeCheck, ChevronDown, ChevronUp, CreditCard, FileText, User } from "lucide-react";
+import { BadgeCheck, ChevronDown, ChevronUp, CreditCard, FileText, Landmark, PiggyBank, User } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
 
@@ -65,6 +65,20 @@ type LoanApplicationSummary = {
   applicationStatus: string;
 };
 
+type DepositAccountSummary = {
+  depositAccountId: number;
+  depositProductName: string;
+  depositProductType: "FIXED_DEPOSIT" | "FIXED_SAVING";
+  depositAccountNumber: string;
+  currentBalance: number;
+  interestRate: number;
+  maturityDate: string;
+  status: string;
+  paidInstallmentCount: number;
+  totalInstallmentCount: number;
+  savingMonth: number;
+};
+
 const quickMenus = [
   {
     title: "회원정보 관리",
@@ -121,9 +135,27 @@ function maskCardNumber(cardNumber: string | null) {
   return `${digitsOnly.slice(0, 4)}-****-****-${digitsOnly.slice(-4)}`;
 }
 
+function formatDepositStatus(status: string) {
+  switch (status) {
+    case "ACTIVE":
+      return "유지중";
+    case "CLOSED":
+      return "만기해지";
+    case "EARLY_CLOSED":
+      return "중도해지";
+    default:
+      return status;
+  }
+}
+
+function getDepositProductLabel(type: DepositAccountSummary["depositProductType"]) {
+  return type === "FIXED_DEPOSIT" ? "정기예금" : "정기적금";
+}
+
 export default function MyPage() {
   const [profile, setProfile] = useState<MyProfile | null>(null);
   const [accounts, setAccounts] = useState<CardHistoryAccount[]>([]);
+  const [depositAccounts, setDepositAccounts] = useState<DepositAccountSummary[]>([]);
   const [loanSummary, setLoanSummary] = useState<MyLoanSummary | null>(null);
   const [loanApplications, setLoanApplications] = useState<LoanApplicationSummary[]>([]);
   const [selectedProductKey, setSelectedProductKey] = useState("");
@@ -138,6 +170,7 @@ export default function MyPage() {
   const [isContactOpen, setIsContactOpen] = useState(false);
   const [isBankingOpen, setIsBankingOpen] = useState(false);
   const [isLoanOpen, setIsLoanOpen] = useState(false);
+  const [isDepositOpen, setIsDepositOpen] = useState(false);
   const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(false);
 
   useEffect(() => {
@@ -148,9 +181,10 @@ export default function MyPage() {
       setErrorMessage("");
 
       try {
-        const [profileResponse, cardHistoryResponse, loanSummaryResponse, loanApplicationsResponse] = await Promise.all([
+        const [profileResponse, cardHistoryResponse, depositAccountsResponse, loanSummaryResponse, loanApplicationsResponse] = await Promise.all([
           getJson<MyProfile>("/api/auth/me"),
           getJson<CardHistoryResponse>("/api/cards/history"),
+          getJson<DepositAccountSummary[]>("/api/deposit-accounts/me").catch(() => []),
           getJson<MyLoanSummary>("/api/loans/me/summary").catch(() => null),
           getJson<LoanApplicationSummary[]>("/api/loan-applications/me").catch(() => []),
         ]);
@@ -161,6 +195,7 @@ export default function MyPage() {
 
         setProfile(profileResponse);
         setAccounts(cardHistoryResponse.accounts);
+        setDepositAccounts(depositAccountsResponse);
         setLoanSummary(loanSummaryResponse);
         setLoanApplications(loanApplicationsResponse);
       } catch (error) {
@@ -171,6 +206,7 @@ export default function MyPage() {
         const message = error instanceof Error ? error.message : "REQUEST_FAILED";
         setProfile(null);
         setAccounts([]);
+        setDepositAccounts([]);
         setLoanSummary(null);
         setLoanApplications([]);
         setErrorMessage(
@@ -245,6 +281,8 @@ export default function MyPage() {
 
   const issuedCards = accounts.filter((account) => account.cardId);
   const totalBalance = accounts.reduce((sum, account) => sum + account.balance, 0);
+  const activeDepositAccounts = depositAccounts.filter((account) => account.status === "ACTIVE");
+  const totalDepositBalance = activeDepositAccounts.reduce((sum, account) => sum + account.currentBalance, 0);
   const sectionToggleClass =
     "flex items-center justify-center p-0 text-slate-400 transition hover:text-slate-600";
   const selectedLoanApplication =
@@ -254,6 +292,9 @@ export default function MyPage() {
     : loanSummary.repaymentType === "MATURITY_LUMP_SUM"
       ? "만기일시상환"
       : "원리금균등분할상환";
+  const featuredDepositAccounts = [...activeDepositAccounts]
+    .sort((left, right) => right.currentBalance - left.currentBalance)
+    .slice(0, 3);
 
   const handleOpenRevealForm = () => {
     setIsRevealFormOpen(true);
@@ -309,7 +350,7 @@ export default function MyPage() {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
             <div className="rounded-3xl border border-sky-100 bg-[linear-gradient(135deg,_rgba(219,234,254,0.95)_0%,_rgba(239,246,255,0.98)_48%,_rgba(248,250,252,1)_100%)] px-5 py-5 text-slate-900 shadow-[0_20px_45px_rgba(148,163,184,0.18)]">
               <p className="text-sm text-slate-500">보유 계좌 · 카드</p>
               <p className="mt-3 text-3xl font-semibold">{accounts.length}개</p>
@@ -317,6 +358,11 @@ export default function MyPage() {
             <div className="rounded-3xl border border-blue-100 bg-blue-50/70 px-5 py-5">
               <p className="text-sm text-slate-500">총 예금 잔액</p>
               <p className="mt-3 text-3xl font-semibold text-slate-900">{formatAmount(totalBalance)}</p>
+            </div>
+            <div className="rounded-3xl border border-emerald-100 bg-emerald-50/70 px-5 py-5">
+              <p className="text-sm text-slate-500">보유 예적금</p>
+              <p className="mt-3 text-3xl font-semibold text-slate-900">{activeDepositAccounts.length}개</p>
+              <p className="mt-2 text-sm text-slate-500">{formatAmount(totalDepositBalance)}</p>
             </div>
           </div>
         </div>
@@ -546,6 +592,108 @@ export default function MyPage() {
                           </span>
                         ))}
                       </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </section>
+
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <button
+                type="button"
+                onClick={() => setIsDepositOpen((prev) => !prev)}
+                className="flex w-full items-center justify-between gap-4 text-left"
+              >
+                <h2 className="text-2xl font-bold text-slate-900">예적금</h2>
+                <span className={sectionToggleClass}>
+                  {isDepositOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                </span>
+              </button>
+
+              {isDepositOpen && (
+                <>
+                  {activeDepositAccounts.length > 0 ? (
+                    <div className="mt-6 space-y-4">
+                      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
+                        <div>
+                          <p className="text-lg font-semibold text-slate-900">유지 중인 예적금</p>
+                        </div>
+                        <Link
+                          to="/deposit/management"
+                          className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                        >
+                          예적금 관리
+                        </Link>
+                      </div>
+
+                      <div className="grid gap-4 xl:grid-cols-3">
+                        {featuredDepositAccounts.map((account) => {
+                          const Icon = account.depositProductType === "FIXED_DEPOSIT" ? Landmark : PiggyBank;
+
+                          return (
+                            <div
+                              key={account.depositAccountId}
+                              className="rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-5"
+                            >
+                              <div className="flex items-start justify-between gap-4">
+                                <div className="flex items-start gap-3">
+                                  <div className="rounded-2xl bg-white p-3 text-sky-700 shadow-sm">
+                                    <Icon className="h-5 w-5" />
+                                  </div>
+                                  <div>
+                                    <p className="text-base font-semibold text-slate-900">{account.depositProductName}</p>
+                                    <p className="mt-1 text-sm text-slate-500">{account.depositAccountNumber}</p>
+                                  </div>
+                                </div>
+                                <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
+                                  {getDepositProductLabel(account.depositProductType)}
+                                </span>
+                              </div>
+
+                              <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                                <div>
+                                  <p className="text-slate-500">현재 상태</p>
+                                  <p className="mt-1 font-semibold text-slate-900">
+                                    {formatDepositStatus(account.status)}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-slate-500">현재 잔액</p>
+                                  <p className="mt-1 font-semibold text-slate-900">
+                                    {formatAmount(account.currentBalance)}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-slate-500">적용 금리</p>
+                                  <p className="mt-1 font-semibold text-slate-900">
+                                    연 {account.interestRate.toFixed(2)}%
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-slate-500">
+                                    {account.depositProductType === "FIXED_SAVING" ? "납입 진행" : "만기일"}
+                                  </p>
+                                  <p className="mt-1 font-semibold text-slate-900">
+                                    {account.depositProductType === "FIXED_SAVING"
+                                      ? `${account.paidInstallmentCount}/${account.totalInstallmentCount || account.savingMonth}`
+                                      : account.maturityDate}
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-5 py-6">
+                      <p className="text-sm text-slate-500">현재 가입한 예적금이 없습니다.</p>
+                      <Link
+                        to="/deposit/products"
+                        className="mt-4 inline-flex rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#5c7c97]"
+                      >
+                        예적금 상품 보러 가기
+                      </Link>
                     </div>
                   )}
                 </>

--- a/src/app/pages/card/DdokgaeCard.tsx
+++ b/src/app/pages/card/DdokgaeCard.tsx
@@ -132,7 +132,7 @@ export default function DdokgaeCard() {
         setCurrentUserName(resolvedUserName);
 
         const nextOwnedCards = response.accounts
-          .filter((account) => account.cardId && account.cardNumber)
+          .filter((account) => account.cardId != null && !!account.cardNumber?.trim())
           .map((account) => ({
             ...account,
             displayLabel: `${account.accountName} ${account.accountNumber}`,

--- a/src/app/pages/card/DdokgaeCard.tsx
+++ b/src/app/pages/card/DdokgaeCard.tsx
@@ -50,6 +50,10 @@ type CardPreview = {
   cardHolderName: string;
 };
 
+type SelectableCard = CardPreviewAccount & {
+  displayLabel: string;
+};
+
 type MyProfile = {
   name: string;
 };
@@ -88,6 +92,8 @@ function formatPreviewExpiredYm(expiredYm: string | null) {
 export default function DdokgaeCard() {
   const navigate = useNavigate();
   const [isApplyDialogOpen, setIsApplyDialogOpen] = useState(false);
+  const [ownedCards, setOwnedCards] = useState<SelectableCard[]>([]);
+  const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
   const [accountName, setAccountName] = useState("");
   const [cardPassword, setCardPassword] = useState("");
   const [submitError, setSubmitError] = useState("");
@@ -125,25 +131,37 @@ export default function DdokgaeCard() {
           : DEFAULT_CARD_PREVIEW.cardHolderName;
         setCurrentUserName(resolvedUserName);
 
-        const ownedCards = response.accounts.filter((account) => account.cardId && account.cardNumber);
-        if (ownedCards.length === 0) {
-          setCardPreview({
-            ...DEFAULT_CARD_PREVIEW,
-            cardHolderName: resolvedUserName,
-          });
-          return;
-        }
+        const nextOwnedCards = response.accounts
+          .filter((account) => account.cardId && account.cardNumber)
+          .map((account) => ({
+            ...account,
+            displayLabel: `${account.accountName} ${account.accountNumber}`,
+          }));
 
-        const randomCard = ownedCards[Math.floor(Math.random() * ownedCards.length)];
-        setCardPreview({
-          cardNumber: formatPreviewCardNumber(randomCard.cardNumber),
-          expiredYm: formatPreviewExpiredYm(randomCard.expiredYm),
-          cardHolderName: resolvedUserName,
-        });
+        setOwnedCards(nextOwnedCards);
+
+        const nextSelectedCard =
+          nextOwnedCards.find((card) => card.cardId === selectedCardId) ?? nextOwnedCards[0] ?? null;
+
+        setSelectedCardId(nextSelectedCard?.cardId ?? null);
+        setCardPreview(
+          nextSelectedCard
+            ? {
+                cardNumber: formatPreviewCardNumber(nextSelectedCard.cardNumber),
+                expiredYm: formatPreviewExpiredYm(nextSelectedCard.expiredYm),
+                cardHolderName: resolvedUserName,
+              }
+            : {
+                ...DEFAULT_CARD_PREVIEW,
+                cardHolderName: resolvedUserName,
+              },
+        );
       } catch {
         if (isMounted) {
           setCurrentUserName(DEFAULT_CARD_PREVIEW.cardHolderName);
           setCardPreview(DEFAULT_CARD_PREVIEW);
+          setOwnedCards([]);
+          setSelectedCardId(null);
         }
       }
     }
@@ -154,6 +172,23 @@ export default function DdokgaeCard() {
       isMounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (selectedCardId == null) {
+      return;
+    }
+
+    const selected = ownedCards.find((card) => card.cardId === selectedCardId) ?? null;
+    if (!selected) {
+      return;
+    }
+
+    setCardPreview({
+      cardNumber: formatPreviewCardNumber(selected.cardNumber),
+      expiredYm: formatPreviewExpiredYm(selected.expiredYm),
+      cardHolderName: currentUserName,
+    });
+  }, [currentUserName, ownedCards, selectedCardId]);
 
   const features = [
     {
@@ -269,7 +304,29 @@ export default function DdokgaeCard() {
                 </div>
               </div>
 
-              <div className="relative">
+              <div className="relative md:-mt-9">
+                {ownedCards.length > 0 && (
+                  <div className="mb-3 flex items-center justify-end gap-3">
+                    <label htmlFor="card-preview-select" className="text-[11px] font-semibold whitespace-nowrap text-slate-500">
+                      표시 카드 선택
+                    </label>
+                    <div className="w-full max-w-[12rem]">
+                      <select
+                        id="card-preview-select"
+                        value={selectedCardId ?? ""}
+                        onChange={(event) => setSelectedCardId(Number(event.target.value))}
+                        className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"
+                      >
+                        {ownedCards.map((card) => (
+                          <option key={card.cardId} value={card.cardId}>
+                            {card.displayLabel}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                )}
+
                 <div className="mx-auto flex max-w-md justify-center">
                   <div className="relative aspect-[1.58/1] w-full overflow-hidden rounded-[2rem] bg-[linear-gradient(135deg,#8ea2ff_0%,#4f66ff_28%,#223dff_64%,#1b28c9_100%)] shadow-[0_14px_36px_rgba(9,11,18,0.28)] ring-1 ring-white/10">
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(255,255,255,0.24),transparent_22%),radial-gradient(circle_at_84%_18%,rgba(255,255,255,0.12),transparent_14%),radial-gradient(circle_at_50%_100%,rgba(111,129,255,0.20),transparent_32%),linear-gradient(180deg,rgba(255,255,255,0.08),transparent_24%)]" />
@@ -320,6 +377,7 @@ export default function DdokgaeCard() {
                 </div>
               </div>
             </div>
+
           </div>
         </div>
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #103 

---

### 📝 작업 내용
- 똑개카드 페이지 카드 선택해서보기, 예적금 관리 페이지 내역 한번에 5개 표기 및 페이지 방식 반영

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계좌 사이드바에 클라이언트 사이드 페이지네이션 추가: 이전/다음 버튼으로 계좌 목록 탐색 가능 및 선택한 계좌에 따라 페이지 자동 이동
  * 카드 선택 드롭다운 추가: 선택한 카드에 따라 카드 미리보기가 즉시 반영
  * 마이페이지에 예적금 섹션 추가: 보유 예적금 요약, 활성 예적금 목록(상태·잔액·이율·만기 진행 등)과 주요 계정 하이라이트

* **버그 수정 / 개선**
  * 카드 미리보기 로드 오류 시 선택 상태 및 목록을 초기화하여 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->