### PR TITLE
Feat: 이전 상품 내역 및 완납 축하 상세 페이지 추가

### DIFF
--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -63,6 +63,19 @@ type LoanApplicationSummary = {
   productKey: string;
   productName: string;
   applicationStatus: string;
+  appliedAt?: string;
+};
+
+type CompletedLoanHistory = {
+  loanHistoryId: number;
+  productKey: string;
+  productName: string;
+  status: string;
+  totalPrincipal: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  completedAt: string;
 };
 
 type DepositAccountSummary = {
@@ -158,6 +171,7 @@ export default function MyPage() {
   const [depositAccounts, setDepositAccounts] = useState<DepositAccountSummary[]>([]);
   const [loanSummary, setLoanSummary] = useState<MyLoanSummary | null>(null);
   const [loanApplications, setLoanApplications] = useState<LoanApplicationSummary[]>([]);
+  const [completedLoans, setCompletedLoans] = useState<CompletedLoanHistory[]>([]);
   const [selectedProductKey, setSelectedProductKey] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
@@ -181,12 +195,20 @@ export default function MyPage() {
       setErrorMessage("");
 
       try {
-        const [profileResponse, cardHistoryResponse, depositAccountsResponse, loanSummaryResponse, loanApplicationsResponse] = await Promise.all([
+        const [
+          profileResponse,
+          cardHistoryResponse,
+          depositAccountsResponse,
+          loanSummaryResponse,
+          loanApplicationsResponse,
+          completedLoansResponse,
+        ] = await Promise.all([
           getJson<MyProfile>("/api/auth/me"),
           getJson<CardHistoryResponse>("/api/cards/history"),
           getJson<DepositAccountSummary[]>("/api/deposit-accounts/me").catch(() => []),
           getJson<MyLoanSummary>("/api/loans/me/summary").catch(() => null),
           getJson<LoanApplicationSummary[]>("/api/loan-applications/me").catch(() => []),
+          getJson<CompletedLoanHistory[]>("/api/loans/me/completed").catch(() => []),
         ]);
 
         if (!isMounted) {
@@ -198,6 +220,7 @@ export default function MyPage() {
         setDepositAccounts(depositAccountsResponse);
         setLoanSummary(loanSummaryResponse);
         setLoanApplications(loanApplicationsResponse);
+        setCompletedLoans(completedLoansResponse);
       } catch (error) {
         if (!isMounted) {
           return;
@@ -209,6 +232,7 @@ export default function MyPage() {
         setDepositAccounts([]);
         setLoanSummary(null);
         setLoanApplications([]);
+        setCompletedLoans([]);
         setErrorMessage(
           message === "UNAUTHORIZED"
             ? "로그인 후 마이페이지를 확인할 수 있습니다."
@@ -228,21 +252,34 @@ export default function MyPage() {
     };
   }, []);
 
+  const isApplicationActive = (application: LoanApplicationSummary) => {
+    const latestCompletedLoan = completedLoans.find((loan) => loan.productKey === application.productKey);
+    if (!latestCompletedLoan) {
+      return true;
+    }
+    if (!application.appliedAt) {
+      return false;
+    }
+    return application.appliedAt.slice(0, 10) >= latestCompletedLoan.completedAt;
+  };
+
+  const activeLoanApplications = loanApplications.filter(isApplicationActive);
+
   useEffect(() => {
-    if (loanApplications.length === 0) {
+    if (activeLoanApplications.length === 0) {
       setSelectedProductKey("");
       return;
     }
 
-    if (loanApplications.some((application) => application.productKey === selectedProductKey)) {
+    if (activeLoanApplications.some((application) => application.productKey === selectedProductKey)) {
       return;
     }
 
     setSelectedProductKey(
-      loanApplications.find((application) => application.productKey === "youth-loan")?.productKey ??
-        loanApplications[0].productKey,
+      activeLoanApplications.find((application) => application.productKey === "youth-loan")?.productKey ??
+        activeLoanApplications[0].productKey,
     );
-  }, [loanApplications, selectedProductKey]);
+  }, [activeLoanApplications, selectedProductKey]);
 
   useEffect(() => {
     if (!selectedProductKey) {
@@ -286,7 +323,7 @@ export default function MyPage() {
   const sectionToggleClass =
     "flex items-center justify-center p-0 text-slate-400 transition hover:text-slate-600";
   const selectedLoanApplication =
-    loanApplications.find((application) => application.productKey === selectedProductKey) ?? null;
+    activeLoanApplications.find((application) => application.productKey === selectedProductKey) ?? null;
   const repaymentMethodLabel = !loanSummary
     ? "상환 방식 정보 없음"
     : loanSummary.repaymentType === "MATURITY_LUMP_SUM"
@@ -458,9 +495,9 @@ export default function MyPage() {
               </button>
               {isLoanOpen && (
                 <>
-                  {loanApplications.length > 0 && (
+                  {activeLoanApplications.length > 0 && (
                     <div className="mt-6 flex flex-wrap gap-2">
-                      {loanApplications.map((application) => {
+                      {activeLoanApplications.map((application) => {
                         const isSelected = application.productKey === selectedProductKey;
                         return (
                           <button
@@ -579,11 +616,11 @@ export default function MyPage() {
                       </p>
                     </div>
                   )}
-                  {loanApplications.length > 0 && (
+                  {activeLoanApplications.length > 0 && (
                     <div className="mt-4 rounded-2xl border border-slate-100 bg-slate-50/80 px-5 py-4">
                       <p className="text-sm text-slate-500">신청 상품</p>
                       <div className="mt-3 flex flex-wrap gap-2">
-                        {loanApplications.map((application) => (
+                        {activeLoanApplications.map((application) => (
                           <span
                             key={application.loanApplicationId}
                             className="rounded-full border border-sky-100 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700"

--- a/src/app/pages/loan/CompletedLoanDetail.tsx
+++ b/src/app/pages/loan/CompletedLoanDetail.tsx
@@ -1,0 +1,425 @@
+import { Award, Calendar, CheckCircle2, ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router";
+import { getJson } from "../../lib/api";
+import { checkAuthentication } from "../../lib/auth";
+
+type CompletedLoanHistory = {
+  loanHistoryId: number;
+  productKey: string;
+  productName: string;
+  status: string;
+  totalPrincipal: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  completedAt: string;
+};
+
+type MyLoanSummary = {
+  loanHistoryId: number;
+  status: string;
+  totalPrincipal: number;
+  remainingPrincipal: number;
+  repaidPrincipal: number;
+  baseInterestRate: number;
+  minimumInterestRate: number;
+  preferentialRateDiscount: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  endDate: string;
+  nextPaymentDate: string | null;
+  nextPaymentPrincipal: number;
+  nextPaymentInterest: number;
+  nextPaymentAmount: number;
+  cumulativeInterest: number;
+  remainingInterestAmount: number;
+  repaymentAccountNumber: string | null;
+};
+
+type MyLoanRepaymentSchedule = {
+  scheduleId: number;
+  dueDate: string;
+  plannedPrincipal: number;
+  plannedInterest: number;
+  paidPrincipal: number;
+  paidInterest: number;
+  settled: boolean;
+  overdueDays: number | null;
+};
+
+type MyLoanRepaymentHistory = {
+  repaymentId: number;
+  repaymentAmount: number;
+  repaymentRate: number;
+  repaymentDatetime: string;
+  remainingBalance: number;
+};
+
+function formatAmount(value: number) {
+  return `${value.toLocaleString("ko-KR")}원`;
+}
+
+export default function CompletedLoanDetail() {
+  const { loanHistoryId } = useParams();
+  const [completedLoans, setCompletedLoans] = useState<CompletedLoanHistory[]>([]);
+  const [summary, setSummary] = useState<MyLoanSummary | null>(null);
+  const [repaymentSchedules, setRepaymentSchedules] = useState<MyLoanRepaymentSchedule[]>([]);
+  const [repaymentHistories, setRepaymentHistories] = useState<MyLoanRepaymentHistory[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRepaymentHistoryExpanded, setIsRepaymentHistoryExpanded] = useState(false);
+
+  useEffect(() => {
+    const loadCompletedLoan = async () => {
+      const isAuthenticated = await checkAuthentication();
+      if (!isAuthenticated || !loanHistoryId) {
+        setCompletedLoans([]);
+        setSummary(null);
+        setRepaymentSchedules([]);
+        setRepaymentHistories([]);
+        setErrorMessage("완납 대출 정보를 확인할 수 없습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const [nextCompletedLoans, nextSummary, nextSchedules, nextHistories] = await Promise.all([
+          getJson<CompletedLoanHistory[]>("/api/loans/me/completed"),
+          getJson<MyLoanSummary>(`/api/loans/me/completed/${loanHistoryId}/summary`),
+          getJson<MyLoanRepaymentSchedule[]>(
+            `/api/loans/me/completed/${loanHistoryId}/repayment-schedules`,
+          ),
+          getJson<MyLoanRepaymentHistory[]>(
+            `/api/loans/me/completed/${loanHistoryId}/repayment-histories`,
+          ),
+        ]);
+
+        setCompletedLoans(nextCompletedLoans);
+        setSummary(nextSummary);
+        setRepaymentSchedules(nextSchedules);
+        setRepaymentHistories(nextHistories);
+      } catch (error) {
+        setCompletedLoans([]);
+        setSummary(null);
+        setRepaymentSchedules([]);
+        setRepaymentHistories([]);
+        setErrorMessage(error instanceof Error ? error.message : "완납 대출 정보를 불러오지 못했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadCompletedLoan();
+  }, [loanHistoryId]);
+
+  const selectedCompletedLoan = useMemo(
+    () => completedLoans.find((loan) => String(loan.loanHistoryId) === loanHistoryId) ?? null,
+    [completedLoans, loanHistoryId],
+  );
+
+  const repaymentMethodLabel =
+    summary?.repaymentType === "MATURITY_LUMP_SUM" ? "만기일시상환" : "원리금균등분할상환";
+  const repaymentMethodDescription =
+    summary?.repaymentType === "MATURITY_LUMP_SUM"
+      ? "매달 이자를 납부하고 만기일에 원금을 한 번에 상환한 상품입니다."
+      : "매달 원금과 이자를 함께 납부해 완납한 상품입니다.";
+  const remainingInterestAmount = summary?.remainingInterestAmount ?? 0;
+  const visibleRepaymentHistories = isRepaymentHistoryExpanded
+    ? repaymentHistories
+    : repaymentHistories.slice(0, 5);
+
+  return (
+    <div className="min-h-screen bg-[#f3f7fb] px-4 py-10 text-slate-900">
+      <div className="mx-auto max-w-6xl">
+        <div className="rounded-[32px] border border-white/70 bg-white/90 shadow-[0_35px_80px_rgba(15,23,42,0.08)] backdrop-blur-xl">
+          <div className="border-b border-slate-100 px-6 py-6 md:px-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-600">
+              Completed Loan
+            </p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+              완납 대출 상세
+            </h1>
+            <p className="mt-2 text-sm text-slate-500">
+              이전에 이용한 대출 상품의 상환 기록과 최종 이용 정보를 확인할 수 있습니다.
+            </p>
+          </div>
+
+          <div className="space-y-8 px-6 py-8 md:px-8 lg:px-10">
+            <section className="rounded-3xl border border-emerald-100 bg-emerald-50/80 px-6 py-6">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="flex items-start gap-4">
+                  <div className="rounded-full bg-white p-3 shadow-sm">
+                    <Award className="h-7 w-7 text-emerald-600" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.18em] text-emerald-600">
+                      Congratulations
+                    </p>
+                    <h2 className="mt-2 text-2xl font-bold text-slate-900">
+                      축하합니다! 완납하셨습니다.
+                    </h2>
+                    <p className="mt-2 text-sm text-slate-600">
+                      {selectedCompletedLoan?.productName ?? "이전 대출 상품"} 상환이 모두 완료되었습니다.
+                    </p>
+                  </div>
+                </div>
+                <Link
+                  to="/loan/management"
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                >
+                  내 대출 관리로 돌아가기
+                </Link>
+              </div>
+            </section>
+
+            {isLoading ? (
+              <section className="rounded-3xl border border-slate-200 bg-slate-50/80 px-6 py-8 text-center text-sm text-slate-500">
+                완납 대출 정보를 불러오는 중입니다.
+              </section>
+            ) : errorMessage || !summary ? (
+              <section className="rounded-3xl border border-amber-200 bg-amber-50 px-6 py-8 text-center text-sm text-amber-800">
+                {errorMessage ?? "완납 대출 정보를 확인할 수 없습니다."}
+              </section>
+            ) : (
+              <>
+                <section className="rounded-3xl border-2 border-white/30 bg-gradient-to-br from-slate-800 via-sky-800 to-emerald-700 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.18)]">
+                  <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+                    <div>
+                      <div className="mb-4 inline-flex rounded-full border border-white/25 bg-white/10 px-4 py-1 text-sm font-semibold backdrop-blur-sm">
+                        이전 상품 내역
+                      </div>
+                      <h3 className="text-3xl font-bold">
+                        {selectedCompletedLoan?.productName ?? "완납 상품"}
+                      </h3>
+                      <p className="mt-3 max-w-2xl text-sm text-slate-100">
+                        기존 대출관리와 같은 기준으로, 이전 대출의 원금·금리·상환 이력을 다시 확인할 수 있습니다.
+                      </p>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                      <div className="rounded-2xl border border-white/20 bg-white/10 px-4 py-4 backdrop-blur-sm">
+                        <p className="text-xs uppercase tracking-[0.18em] text-slate-100">최종 금리</p>
+                        <p className="mt-2 text-2xl font-bold">연 {summary.interestRate.toFixed(1)}%</p>
+                      </div>
+                      <div className="rounded-2xl border border-white/20 bg-white/10 px-4 py-4 backdrop-blur-sm">
+                        <p className="text-xs uppercase tracking-[0.18em] text-slate-100">총 원금</p>
+                        <p className="mt-2 text-2xl font-bold">{formatAmount(summary.totalPrincipal)}</p>
+                      </div>
+                      <div className="rounded-2xl border border-white/20 bg-white/10 px-4 py-4 backdrop-blur-sm">
+                        <p className="text-xs uppercase tracking-[0.18em] text-slate-100">완납일</p>
+                        <p className="mt-2 text-2xl font-bold">
+                          {selectedCompletedLoan?.completedAt ?? summary.endDate}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="grid gap-4 md:grid-cols-4">
+                  <div className="rounded-3xl border border-sky-100 bg-sky-50/80 px-5 py-5">
+                    <p className="text-sm text-slate-500">잔여 원금</p>
+                    <p className="mt-3 text-3xl font-semibold text-slate-900">
+                      {formatAmount(summary.remainingPrincipal)}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
+                    <p className="text-sm text-slate-500">총 원금</p>
+                    <p className="mt-3 text-2xl font-bold text-slate-900">
+                      {formatAmount(summary.totalPrincipal)}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-emerald-100 bg-emerald-50/80 px-5 py-5">
+                    <p className="text-sm text-slate-500">누적 상환 원금</p>
+                    <p className="mt-3 text-2xl font-bold text-slate-900">
+                      {formatAmount(summary.repaidPrincipal)}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
+                    <p className="text-sm text-slate-500">금리</p>
+                    <p className="mt-3 text-2xl font-bold text-slate-900">
+                      연 {summary.interestRate.toFixed(1)}%
+                    </p>
+                  </div>
+                </section>
+
+                <section className="grid gap-4 lg:grid-cols-3">
+                  <div className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                    <p className="text-sm text-slate-500">상환 방식</p>
+                    <p className="mt-2 text-xl font-bold text-slate-900">{repaymentMethodLabel}</p>
+                    <p className="mt-2 text-sm text-slate-600">{repaymentMethodDescription}</p>
+                  </div>
+                  <div className="rounded-3xl border border-slate-200 bg-slate-50 px-5 py-5">
+                    <p className="text-sm text-slate-500">대출 기간</p>
+                    <p className="mt-2 text-xl font-bold text-slate-900">
+                      {summary.startDate} ~ {summary.endDate}
+                    </p>
+                    <p className="mt-2 text-sm text-slate-600">
+                      완납일 {selectedCompletedLoan?.completedAt ?? summary.endDate}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-emerald-100 bg-emerald-50/70 px-5 py-5">
+                    <p className="text-sm text-slate-500">완납 상태</p>
+                    <p className="mt-2 text-xl font-bold text-slate-900">완납 완료</p>
+                    <p className="mt-2 text-sm text-slate-600">
+                      상환 일정과 최근 상환 내역은 아래에서 그대로 확인할 수 있습니다.
+                    </p>
+                  </div>
+                </section>
+
+                <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
+                  <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                    <div className="flex items-center justify-between gap-3">
+                      <h2 className="text-xl font-bold text-slate-900">최근 상환 내역</h2>
+                      {repaymentHistories.length > 5 && (
+                        <button
+                          type="button"
+                          onClick={() => setIsRepaymentHistoryExpanded((prev) => !prev)}
+                          className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+                        >
+                          {isRepaymentHistoryExpanded ? "접기" : "더보기"}
+                          {isRepaymentHistoryExpanded ? (
+                            <ChevronUp className="h-4 w-4" />
+                          ) : (
+                            <ChevronDown className="h-4 w-4" />
+                          )}
+                        </button>
+                      )}
+                    </div>
+                    <div className="mt-5 space-y-3">
+                      {visibleRepaymentHistories.map((repayment) => (
+                        <div
+                          key={repayment.repaymentId}
+                          className="flex flex-col gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4 md:flex-row md:items-center md:justify-between"
+                        >
+                          <div>
+                            <p className="text-sm text-slate-500">
+                              {repayment.repaymentDatetime.slice(0, 10)}
+                            </p>
+                            <p className="mt-1 text-lg font-semibold text-slate-900">
+                              {formatAmount(repayment.repaymentAmount)}
+                            </p>
+                          </div>
+                          <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-2 md:gap-8">
+                            <div>
+                              <p className="text-slate-500">적용 금리</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                연 {repayment.repaymentRate.toFixed(1)}%
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-slate-500">상환 후 잔액</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                {formatAmount(repayment.remainingBalance)}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                      {repaymentHistories.length === 0 && (
+                        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-5 text-sm text-slate-500">
+                          상환 내역이 없습니다.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                    <h2 className="text-xl font-bold text-slate-900">이자 정보</h2>
+                    <div className="mt-5 space-y-4">
+                      <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
+                        <p className="text-sm text-slate-500">누적 납입 이자</p>
+                        <p className="mt-2 text-2xl font-bold text-slate-900">
+                          {formatAmount(summary.cumulativeInterest)}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
+                        <p className="text-sm text-slate-500">잔여 예상 이자</p>
+                        <p className="mt-2 text-2xl font-bold text-slate-900">
+                          {formatAmount(remainingInterestAmount)}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4">
+                        <p className="text-sm text-slate-500">완납 요약</p>
+                        <p className="mt-2 text-sm text-slate-600">
+                          마지막 납입일{" "}
+                          <span className="font-semibold text-slate-900">
+                            {selectedCompletedLoan?.completedAt ?? summary.endDate}
+                          </span>
+                        </p>
+                        <p className="mt-1 text-sm text-slate-600">
+                          현재 상태{" "}
+                          <span className="font-semibold text-slate-900">{summary.status}</span>
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+                  <div className="mb-5 flex items-center gap-3">
+                    <div className="rounded-full bg-sky-100 p-2">
+                      <Calendar className="h-5 w-5 text-sky-700" />
+                    </div>
+                    <h2 className="text-xl font-bold text-slate-900">상환 일정</h2>
+                  </div>
+                  <div className="mt-5 space-y-3">
+                    {repaymentSchedules.map((schedule) => (
+                      <div
+                        key={schedule.scheduleId}
+                        className="rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-4"
+                      >
+                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                          <div>
+                            <p className="text-sm text-slate-500">{schedule.dueDate}</p>
+                            <p className="mt-1 text-base font-semibold text-slate-900">
+                              {schedule.settled ? "납부 완료" : "납부 예정"}
+                            </p>
+                          </div>
+                          <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-2 lg:grid-cols-4">
+                            <div>
+                              <p className="text-slate-500">예정 원금</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                {formatAmount(schedule.plannedPrincipal)}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-slate-500">예정 이자</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                {formatAmount(schedule.plannedInterest)}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-slate-500">납부 원금</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                {formatAmount(schedule.paidPrincipal)}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-slate-500">납부 이자</p>
+                              <p className="mt-1 font-semibold text-slate-900">
+                                {formatAmount(schedule.paidInterest)}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                    {repaymentSchedules.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-5 text-sm text-slate-500">
+                        상환 일정이 없습니다.
+                      </div>
+                    )}
+                  </div>
+                </section>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/loan/LoanApply.tsx
+++ b/src/app/pages/loan/LoanApply.tsx
@@ -76,7 +76,7 @@ const productConfigs: Record<string, LoanApplyConfig> = {
     subtitle: "자격증, 어학, 직무 교육 등 자기계발 비용을 준비하는 청년 대상 상품입니다.",
     limit: "최대 500만원",
     period: "12개월 ~ 24개월",
-    rate: "연 3.8% ~ 6.2%",
+    rate: "연 5.5% (우대 적용 시 최저 3.5%)",
     defaultAmount: "3000000",
     defaultPurpose: "자격증 및 직무 교육 준비",
     amountRange: { min: 500000, max: 5000000 },

--- a/src/app/pages/loan/LoanDetail.tsx
+++ b/src/app/pages/loan/LoanDetail.tsx
@@ -35,6 +35,18 @@ type LoanApplicationSummary = {
   certificateSubmitted: boolean;
 };
 
+type CompletedLoanHistory = {
+  loanHistoryId: number;
+  productKey: string;
+  productName: string;
+  status: string;
+  totalPrincipal: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  completedAt: string;
+};
+
 type DetailTab = "guide" | "rate" | "terms" | "caution";
 
 const loanDetails: Record<string, LoanDetailItem> = {
@@ -81,7 +93,7 @@ const loanDetails: Record<string, LoanDetailItem> = {
     target: "만 19세 ~ 29세 청년 고객",
     limit: "최소 50만원 ~ 최대 500만원",
     period: "12개월 ~ 24개월",
-    rate: "연 3.8% ~ 6.2%",
+    rate: "연 5.5% 시작 (우대 적용 시 최저 3.5%)",
     guide: [
       "자격증, 어학, 실무 교육 등 자기계발 목적에 맞는 자금을 지원합니다.",
       "대출 신청 후 내 대출 관리에서 서류를 제출하면 심사가 이어집니다.",
@@ -152,6 +164,7 @@ export default function LoanDetail() {
   const { productId } = useParams<{ productId: string }>();
   const product = productId ? loanDetails[productId] : undefined;
   const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
+  const [completedLoans, setCompletedLoans] = useState<CompletedLoanHistory[]>([]);
   const [activeTab, setActiveTab] = useState<DetailTab>("guide");
 
   useEffect(() => {
@@ -159,14 +172,20 @@ export default function LoanDetail() {
       const isAuthenticated = await checkAuthentication();
       if (!isAuthenticated) {
         setApplications([]);
+        setCompletedLoans([]);
         return;
       }
 
       try {
-        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        const [nextApplications, nextCompletedLoans] = await Promise.all([
+          getJson<LoanApplicationSummary[]>("/api/loan-applications/me"),
+          getJson<CompletedLoanHistory[]>("/api/loans/me/completed"),
+        ]);
         setApplications(nextApplications);
+        setCompletedLoans(nextCompletedLoans);
       } catch {
         setApplications([]);
+        setCompletedLoans([]);
       }
     };
 
@@ -180,10 +199,17 @@ export default function LoanDetail() {
     };
   }, []);
 
-  const application = useMemo(
+  const latestApplication = useMemo(
     () => applications.find((item) => item.productKey === productId) ?? null,
     [applications, productId],
   );
+  const latestCompletedLoan = useMemo(
+    () => completedLoans.find((item) => item.productKey === productId) ?? null,
+    [completedLoans, productId],
+  );
+  const isInUse =
+    !!latestApplication &&
+    (!latestCompletedLoan || latestApplication.appliedAt.slice(0, 10) >= latestCompletedLoan.completedAt);
 
   const handlePrimaryAction = () => {
     if (!productId || !product) {
@@ -191,7 +217,7 @@ export default function LoanDetail() {
       return;
     }
 
-    if (application) {
+    if (isInUse) {
       navigate("/loan/management");
       return;
     }
@@ -269,9 +295,9 @@ export default function LoanDetail() {
 
       <div className="mb-8 rounded-3xl border border-[#d7e5f5] bg-[linear-gradient(135deg,_#edf4fb_0%,_#dfeefb_50%,_#f8fbff_100%)] p-8 text-center text-slate-900 shadow-xl">
         <h3 className="mb-2 text-2xl font-bold">상품 내용을 확인한 뒤 바로 신청할 수 있습니다</h3>
-        {application && (
+        {latestApplication && isInUse && (
           <div className="mb-4 inline-flex rounded-full border border-emerald-600/70 bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
-            {getApplicationStatusLabel(application)}
+            {getApplicationStatusLabel(latestApplication)}
           </div>
         )}
         <p className="mb-6 text-slate-600">
@@ -286,7 +312,7 @@ export default function LoanDetail() {
           onClick={handlePrimaryAction}
           className="rounded-xl bg-[#6d8ca6] px-8 py-3 font-semibold text-white shadow-md transition-all hover:bg-[#5c7c97]"
         >
-          {application ? "내 대출 관리 보기" : "대출 신청하기"}
+          {isInUse ? "내 대출 관리 보기" : "대출 신청하기"}
         </button>
       </div>
 

--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -27,6 +27,18 @@ type LoanApplicationSummary = {
   certificateSubmitted: boolean;
 };
 
+type CompletedLoanHistory = {
+  loanHistoryId: number;
+  productKey: string;
+  productName: string;
+  status: string;
+  totalPrincipal: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  completedAt: string;
+};
+
 function getApplicationStatusLabel(application: LoanApplicationSummary) {
   switch (application.applicationStatus) {
     case "DOCUMENT_REQUIRED":
@@ -60,7 +72,7 @@ const loanProducts: LoanProduct[] = [
     id: "youth-loan",
     name: "자기계발 대출",
     badge: "청년 특화",
-    rate: "연 3.8% ~ 6.2%",
+    rate: "연 5.5% (우대 적용 시 최저 3.5%)",
     limit: "최대 500만원",
     period: "12개월 ~ 24개월",
     target: "만 19세 ~ 29세 청년",
@@ -85,20 +97,27 @@ const loanProducts: LoanProduct[] = [
 export default function LoanProducts() {
   const navigate = useNavigate();
   const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
+  const [completedLoans, setCompletedLoans] = useState<CompletedLoanHistory[]>([]);
 
   useEffect(() => {
     const syncApplications = async () => {
       const isAuthenticated = await checkAuthentication();
       if (!isAuthenticated) {
         setApplications([]);
+        setCompletedLoans([]);
         return;
       }
 
       try {
-        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        const [nextApplications, nextCompletedLoans] = await Promise.all([
+          getJson<LoanApplicationSummary[]>("/api/loan-applications/me"),
+          getJson<CompletedLoanHistory[]>("/api/loans/me/completed"),
+        ]);
         setApplications(nextApplications);
+        setCompletedLoans(nextCompletedLoans);
       } catch {
         setApplications([]);
+        setCompletedLoans([]);
       }
     };
 
@@ -121,12 +140,31 @@ export default function LoanProducts() {
     [],
   );
 
-  const getApplication = (productId: string) =>
+  const getLatestApplication = (productId: string) =>
     applications.find((application) => application.productKey === productId) ?? null;
 
+  const getLatestCompletedLoan = (productId: string) =>
+    completedLoans.find((loan) => loan.productKey === productId) ?? null;
+
+  const isApplicationOnOrAfterCompletedLoan = (
+    application: LoanApplicationSummary,
+    completedLoan: CompletedLoanHistory,
+  ) => application.appliedAt.slice(0, 10) >= completedLoan.completedAt;
+
+  const isProductInUse = (productId: string) => {
+    const latestApplication = getLatestApplication(productId);
+    const latestCompletedLoan = getLatestCompletedLoan(productId);
+    if (!latestApplication) {
+      return false;
+    }
+    if (!latestCompletedLoan) {
+      return true;
+    }
+    return isApplicationOnOrAfterCompletedLoan(latestApplication, latestCompletedLoan);
+  };
+
   const handleApply = (product: LoanProduct) => {
-    const existing = getApplication(product.id);
-    if (existing) {
+    if (isProductInUse(product.id)) {
       navigate("/loan/management");
       return;
     }
@@ -153,7 +191,8 @@ export default function LoanProducts() {
 
         <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
           {primaryProducts.map((product) => {
-            const application = getApplication(product.id);
+            const application = getLatestApplication(product.id);
+            const isInUse = isProductInUse(product.id);
 
             return (
               <section
@@ -167,7 +206,7 @@ export default function LoanProducts() {
                       {product.badge}
                     </span>
                   )}
-                  {application && (
+                  {application && isInUse && (
                     <span className="rounded-full border border-emerald-600/70 bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
                       {getApplicationStatusLabel(application)}
                     </span>
@@ -217,7 +256,7 @@ export default function LoanProducts() {
                     className="flex-1 rounded-xl border border-[#2a4b78] bg-[#2a4b78] py-4 font-bold text-white shadow-md transition-all hover:bg-[#223f64]"
                   >
                     <span style={{ color: "#fff" }}>
-                      {application ? "내 대출 관리 보기" : "대출 신청하기"}
+                      {isInUse ? "내 대출 관리 보기" : "대출 신청하기"}
                     </span>
                   </button>
                 </div>
@@ -228,7 +267,8 @@ export default function LoanProducts() {
 
         <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
           {secondaryProducts.map((product) => {
-            const application = getApplication(product.id);
+            const application = getLatestApplication(product.id);
+            const isInUse = isProductInUse(product.id);
 
             return (
             <div
@@ -237,7 +277,7 @@ export default function LoanProducts() {
             >
               <div className="mb-4 flex items-center justify-between gap-3">
                 <h3 className="text-xl font-bold text-white">{product.name}</h3>
-                {application && (
+                {application && isInUse && (
                   <span className="rounded-full border border-emerald-600/70 bg-emerald-600 px-3 py-1 text-xs font-semibold text-white shadow-sm">
                     {getApplicationStatusLabel(application)}
                   </span>
@@ -264,7 +304,7 @@ export default function LoanProducts() {
                 className="mt-3 block w-full rounded-xl border border-[#2a4b78] bg-[#2a4b78] py-3 text-center font-bold text-white shadow-sm transition-all hover:bg-[#223f64]"
               >
                 <span style={{ color: "#fff" }}>
-                  {application ? "내 대출 관리 보기" : "대출 신청하기"}
+                  {isInUse ? "내 대출 관리 보기" : "대출 신청하기"}
                 </span>
               </button>
             </div>

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -1,4 +1,4 @@
-﻿import { Calendar, Calculator, ChevronDown, ChevronUp, FileSearch, TrendingDown, Upload } from "lucide-react";
+﻿﻿import { Calendar, Calculator, ChevronDown, ChevronUp, FileSearch, TrendingDown, Upload } from "lucide-react";
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { getJson, postJson } from "../../lib/api";
@@ -15,6 +15,18 @@ type LoanApplicationSummary = {
   preferentialRateVerificationAvailable: boolean;
   preferentialRateVerificationSubmitted: boolean;
   preferentialRateVerificationStatus: string | null;
+};
+
+type CompletedLoanHistory = {
+  loanHistoryId: number;
+  productKey: string;
+  productName: string;
+  status: string;
+  totalPrincipal: number;
+  interestRate: number;
+  repaymentType: string;
+  startDate: string;
+  completedAt: string;
 };
 
 type UploadStatus = "idle" | "selected" | "uploading" | "completed" | "failed";
@@ -211,6 +223,7 @@ export default function MyLoanManagement() {
   const loanManagementRequestIdRef = useRef(0);
   const [simulationAmount, setSimulationAmount] = useState(1000000);
   const [applications, setApplications] = useState<LoanApplicationSummary[]>([]);
+  const [completedLoans, setCompletedLoans] = useState<CompletedLoanHistory[]>([]);
   const [summary, setSummary] = useState<MyLoanSummary | null>(null);
   const [repaymentSchedules, setRepaymentSchedules] = useState<MyLoanRepaymentSchedule[]>([]);
   const [repaymentHistories, setRepaymentHistories] = useState<MyLoanRepaymentHistory[]>([]);
@@ -226,6 +239,19 @@ export default function MyLoanManagement() {
   const [repaymentActionMessage, setRepaymentActionMessage] = useState<string | null>(null);
   const [isRepaymentSubmitting, setIsRepaymentSubmitting] = useState(false);
   const [isRepaymentHistoryExpanded, setIsRepaymentHistoryExpanded] = useState(false);
+
+  const isApplicationOnOrAfterCompletedLoan = (
+    application: LoanApplicationSummary,
+    completedLoan: CompletedLoanHistory,
+  ) => application.appliedAt.slice(0, 10) >= completedLoan.completedAt;
+
+  const isApplicationActive = (application: LoanApplicationSummary) => {
+    const latestCompletedLoan = completedLoans.find((loan) => loan.productKey === application.productKey);
+    if (!latestCompletedLoan) {
+      return true;
+    }
+    return isApplicationOnOrAfterCompletedLoan(application, latestCompletedLoan);
+  };
 
   const refreshLoanManagement = async () => {
     const requestId = ++loanManagementRequestIdRef.current;
@@ -277,17 +303,23 @@ export default function MyLoanManagement() {
       const isAuthenticated = await checkAuthentication();
       if (!isAuthenticated) {
         setApplications([]);
+        setCompletedLoans([]);
         return;
       }
 
       try {
-        const nextApplications = await getJson<LoanApplicationSummary[]>("/api/loan-applications/me");
+        const [nextApplications, nextCompletedLoans] = await Promise.all([
+          getJson<LoanApplicationSummary[]>("/api/loan-applications/me"),
+          getJson<CompletedLoanHistory[]>("/api/loans/me/completed"),
+        ]);
         if (requestId === applicationsRequestIdRef.current) {
           setApplications(nextApplications);
+          setCompletedLoans(nextCompletedLoans);
         }
       } catch {
         if (requestId === applicationsRequestIdRef.current) {
           setApplications([]);
+          setCompletedLoans([]);
         }
       }
     };
@@ -326,21 +358,26 @@ export default function MyLoanManagement() {
     );
   }, [summary?.remainingPrincipal]);
 
+  const activeApplications = useMemo(
+    () => applications.filter(isApplicationActive),
+    [applications, completedLoans],
+  );
+
   useEffect(() => {
-    if (applications.length === 0) {
+    if (activeApplications.length === 0) {
       setSelectedProductKey("");
       return;
     }
 
-    if (applications.some((application) => application.productKey === selectedProductKey)) {
+    if (activeApplications.some((application) => application.productKey === selectedProductKey)) {
       return;
     }
 
     setSelectedProductKey(
-      applications.find((application) => application.productKey === "youth-loan")?.productKey ??
-        applications[0].productKey,
+      activeApplications.find((application) => application.productKey === "youth-loan")?.productKey ??
+        activeApplications[0].productKey,
     );
-  }, [applications, selectedProductKey]);
+  }, [activeApplications, selectedProductKey]);
 
   const repaidPrincipal = summary?.repaidPrincipal ?? 0;
   const repaymentProgress =
@@ -374,10 +411,7 @@ export default function MyLoanManagement() {
   const remainingInterestAmount = summary?.remainingInterestAmount ?? 0;
   const hasLoanData = !!summary;
   const showLoanLoadingState = isLoanDataLoading && !hasLoanData;
-  const showLoanEmptyState =
-    !isLoanDataLoading &&
-    !hasLoanData &&
-    loanDataError === "대출 관리 정보가 없습니다.";
+  const shouldShowLoanEmptyState = !isLoanDataLoading && activeApplications.length === 0;
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -393,10 +427,10 @@ export default function MyLoanManagement() {
 
   const selectedApplication = useMemo(
     () =>
-      applications.find((application) => application.productKey === selectedProductKey) ??
-      applications[0] ??
+      activeApplications.find((application) => application.productKey === selectedProductKey) ??
+      activeApplications[0] ??
       null,
-    [applications, selectedProductKey],
+    [activeApplications, selectedProductKey],
   );
   const canSubmitCertificate = !!selectedApplication?.preferentialRateVerificationAvailable;
   const isYouthLoanSelected = selectedApplication?.productKey === "youth-loan";
@@ -626,7 +660,7 @@ export default function MyLoanManagement() {
         </div>
 
         <div className="space-y-8 px-6 py-8 md:px-8 lg:px-10">
-          {applications.length > 0 && (
+          {activeApplications.length > 0 && (
             <section className="rounded-3xl border border-slate-200 bg-slate-50/80 px-5 py-5">
               <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div>
@@ -639,7 +673,7 @@ export default function MyLoanManagement() {
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {applications.map((application) => {
+                  {activeApplications.map((application) => {
                     const isSelected = application.productKey === selectedProductKey;
                     return (
                       <button
@@ -661,22 +695,90 @@ export default function MyLoanManagement() {
             </section>
           )}
 
+          {completedLoans.length > 0 && (
+            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_18px_40px_rgba(15,23,42,0.05)]">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-600">
+                    Completed Products
+                  </p>
+                  <h2 className="mt-2 text-xl font-bold text-slate-900">이전 상품 내역</h2>
+                  <p className="mt-2 text-sm text-slate-500">
+                    완납한 상품을 선택하면 축하 페이지와 이전 이용 정보를 확인할 수 있습니다.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {completedLoans.map((loan) => (
+                    <Link
+                      key={loan.loanHistoryId}
+                      to={`/loan/management/completed/${loan.loanHistoryId}`}
+                      className="rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-300 hover:bg-emerald-100"
+                    >
+                      {loan.productName}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
+
           {showLoanLoadingState ? (
             <section className="rounded-3xl border border-slate-200 bg-slate-50/80 px-6 py-8 text-center text-sm text-slate-500">
               대출 관리 정보를 불러오는 중입니다.
             </section>
-          ) : showLoanEmptyState ? (
-            <section className="rounded-3xl border border-dashed border-slate-200 bg-slate-50/80 px-6 py-8 text-center">
-              <h2 className="text-xl font-bold text-slate-900">대출 관리 정보가 없습니다</h2>
-              <p className="mt-2 text-sm text-slate-500">
-                현재 실행된 대출 데이터가 없어 관리 정보를 표시할 수 없습니다.
-              </p>
-              <Link
-                to="/loan/products"
-                className="mt-4 inline-block rounded-xl bg-[#6d8ca6] px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-[#5c7c97]"
-              >
-                대출 상품 보러가기
-              </Link>
+          ) : shouldShowLoanEmptyState ? (
+            <section className="rounded-[32px] border border-white/70 bg-gradient-to-br from-slate-900 via-sky-900 to-emerald-700 px-6 py-10 text-white shadow-[0_30px_70px_rgba(15,23,42,0.18)]">
+              <div className="max-w-4xl">
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-200">
+                  Loan Start
+                </p>
+                <h2 className="mt-3 text-3xl font-bold tracking-tight">
+                  아직 진행 중인 대출이 없습니다
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-100">
+                  소비분석 대출과 자기계발 대출 상품을 비교하고, 지금 필요한 대출을 바로 신청할 수 있습니다.
+                  완납한 상품은 위의 이전 상품 내역에서 다시 확인할 수 있습니다.
+                </p>
+              </div>
+
+              <div className="mt-8 grid gap-4 md:grid-cols-3">
+                <div className="rounded-3xl border border-white/15 bg-white/10 px-5 py-5 backdrop-blur-sm">
+                  <p className="text-sm text-sky-100">소비분석 대출</p>
+                  <p className="mt-3 text-2xl font-bold">최대 300만원</p>
+                  <p className="mt-2 text-sm text-slate-100">
+                    소비 패턴 기반으로 한도와 상환 계획을 확인할 수 있습니다.
+                  </p>
+                </div>
+                <div className="rounded-3xl border border-white/15 bg-white/10 px-5 py-5 backdrop-blur-sm">
+                  <p className="text-sm text-sky-100">자기계발 대출</p>
+                  <p className="mt-3 text-2xl font-bold">최대 500만원</p>
+                  <p className="mt-2 text-sm text-slate-100">
+                    자격증 OCR 인증과 우대금리 혜택을 함께 확인할 수 있습니다.
+                  </p>
+                </div>
+                <div className="rounded-3xl border border-white/15 bg-white/10 px-5 py-5 backdrop-blur-sm">
+                  <p className="text-sm text-sky-100">신청 후 관리</p>
+                  <p className="mt-3 text-2xl font-bold">상환 일정 관리</p>
+                  <p className="mt-2 text-sm text-slate-100">
+                    신청 이후에는 상환 일정, 이자 정보, 이전 상품 내역을 한 번에 확인합니다.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  to="/loan/products"
+                  className="inline-flex items-center justify-center rounded-2xl bg-white px-5 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-100"
+                >
+                  대출 상품 보러가기
+                </Link>
+                <Link
+                  to="/loan/credit-score"
+                  className="inline-flex items-center justify-center rounded-2xl border border-white/25 bg-white/10 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/15"
+                >
+                  내 신용 점수 확인하기
+                </Link>
+              </div>
             </section>
           ) : (
             <>
@@ -935,7 +1037,7 @@ export default function MyLoanManagement() {
             </div>
           )}
 
-          {loanDataError && !isLoanDataLoading && !showLoanEmptyState && (
+          {loanDataError && !isLoanDataLoading && !shouldShowLoanEmptyState && !hasLoanData && (
             <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800">
               {loanDataError === "대출 관리 정보가 없습니다."
                 ? "현재 조회할 대출 관리 정보가 없습니다."

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -13,6 +13,7 @@ import LoanDetail from "./pages/loan/LoanDetail";
 import LoanApply from "./pages/loan/LoanApply";
 import MyLoanManagement from "./pages/loan/MyLoanManagement";
 import MyCreditScore from "./pages/loan/MyCreditScore";
+import CompletedLoanDetail from "./pages/loan/CompletedLoanDetail";
 import DdokgaeCard from "./pages/card/DdokgaeCard";
 import CardHistory from "./pages/card/CardHistory";
 import SpendingAnalysis from "./pages/card/SpendingAnalysis";
@@ -39,6 +40,7 @@ export const router = createBrowserRouter([
       { path: "loan/products/:productId", Component: LoanDetail },
       { path: "loan/products/:productId/apply", Component: LoanApply },
       { path: "loan/management", Component: MyLoanManagement },
+      { path: "loan/management/completed/:loanHistoryId", Component: CompletedLoanDetail },
       { path: "loan/credit-score", Component: MyCreditScore },
       { path: "card/ddokgae", Component: DdokgaeCard },
       { path: "card/history", Component: CardHistory },


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #109 

---

### 📝 작업 내용
- 내 대출 관리 화면 상단에 완납된 상품을 보여주는 `이전 상품 내역` 섹션을 추가했습니다.
- 이전 상품을 클릭하면 새 페이지로 이동해 완납 축하 메시지와 함께 기존 대출 관리와 유사한 상세 정보를 볼 수 있도록 완납 상세 페이지를 추가했습니다.
- 마이페이지와 대출 관리 화면에서는 완납된 상품이 현재 진행 중 상품처럼 중첩 표시되지 않도록 활성 상품 판별 로직을 정리했습니다.


---

### 📷 스크린샷 (선택)
- <img width="1033" height="813" alt="image" src="https://github.com/user-attachments/assets/0dbc3024-fb7c-442a-9747-43b7e4f145ba" />

- <img width="1098" height="399" alt="image" src="https://github.com/user-attachments/assets/1d09dea9-f406-4d8b-947b-95eec92a84ed" />




---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
