### PR TITLE
Fix: 챗봇 내 페이지 이동 시 플로팅 창이 닫히는 문제 수정

### DIFF
--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -5,7 +5,6 @@ import ChatBot from "./components/ChatBot";
 
 export default function Root() {
   const location = useLocation();
-  const isChatHistoryPage = location.pathname === "/help/chat-history";
   const isAdminPage = location.pathname.startsWith("/admin/");
   const isHomePage = location.pathname === "/";
 
@@ -19,7 +18,7 @@ export default function Root() {
         <div>
           <Footer />
         </div>
-        {!isChatHistoryPage && !isAdminPage ? <ChatBot /> : null}
+        {!isAdminPage ? <ChatBot /> : null}{" "}
       </div>
     </div>
   );

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -7,6 +7,7 @@ export default function Root() {
   const location = useLocation();
   const isAdminPage = location.pathname.startsWith("/admin/");
   const isHomePage = location.pathname === "/";
+  const isChatHistoryPage = location.pathname === "/help/chat-history";
 
   return (
     <div className="min-h-screen flex flex-col bg-white">
@@ -18,8 +19,7 @@ export default function Root() {
         <div>
           <Footer />
         </div>
-        {!isAdminPage ? <ChatBot /> : null}{" "}
-      </div>
+        {!isAdminPage && !isChatHistoryPage ? <ChatBot /> : null}      </div>
     </div>
   );
 }

--- a/src/app/components/ChatBot.tsx
+++ b/src/app/components/ChatBot.tsx
@@ -299,7 +299,7 @@ export default function ChatBot() {
 
   const handleQuickReplyClick = async (reply: ChatAction) => {
     if (reply.type === "navigate") {
-      setIsOpen(false);
+      //setIsOpen(false);
       navigate(reply.href);
       return;
     }
@@ -368,7 +368,7 @@ export default function ChatBot() {
                       onNavigateClick={
                         message.sender === "bot"
                           ? (href) => {
-                              setIsOpen(false);
+                              //setIsOpen(false);
                               navigate(href);
                             }
                           : undefined

--- a/src/app/pages/Home.tsx
+++ b/src/app/pages/Home.tsx
@@ -11,7 +11,7 @@ import homeBanner3 from "../../assets/home/card.png";
 
 const heroSlides = [
     {
-        title: "카드 쓰고, 소비 흐름까지 보기",
+        title: "카드 쓰고, 소비 흐름까지",
         subtitle: "체크카드 이용 내역과 AI 소비 분석을 함께 관리",
         actionLabel: "카드 신청하기",
         actionTo: "/card/nudgecard",


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #179 

---

### 📝 작업 내용
챗봇에서 페이지 이동 버튼을 누르면 플로팅 챗봇 창이 닫히는 문제가 있습니다.
ChatBot.tsx에서 페이지 이동 처리 전에 setIsOpen(false)를 호출해 챗봇 창을 직접 닫고 있습니다.
ChatBot.tsx에서는 페이지 이동 시 setIsOpen(false) 호출을 제거합니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 기록 페이지에서 챗봇이 정상적으로 표시됩니다.
  * 챗봇 빠른 응답 및 링크 클릭 시 챗봇 창이 자동으로 닫히지 않습니다.

* **UI 개선**
  * 홈 페이지 타이틀 텍스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->