### PR TITLE
Refactor: 마이페이지, 신용평가 페이지 글자색이랑 글자크기 조정

### DIFF
--- a/src/app/pages/account/MyPage.tsx
+++ b/src/app/pages/account/MyPage.tsx
@@ -797,7 +797,7 @@ export default function MyPage() {
                         <p className="text-sm text-slate-500">현재 보유한 계좌가 없습니다.</p>
                         <Link
                           to="/account/nudgecard"
-className="mt-4 inline-flex rounded-xl bg-black px-4 py-3 text-sm font-semibold text-white transition hover:bg-gray-800"
+                          className="mt-4 inline-flex rounded-xl bg-black px-4 py-3 text-sm font-semibold transition hover:bg-gray-800"
                           style={{ color: "#ffffff" }}
                         >
                           계좌 개설하러 가기
@@ -857,7 +857,7 @@ className="mt-4 inline-flex rounded-xl bg-black px-4 py-3 text-sm font-semibold 
                                 type="button"
                                 onClick={handleConfirmReveal}
                                 disabled={isVerifyingPassword}
-className="rounded-xl bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+                                className="rounded-xl bg-black px-4 py-2 text-sm font-semibold transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
                                 style={isVerifyingPassword ? undefined : { color: "#ffffff" }}
                               >
                                 {isVerifyingPassword ? "확인 중" : "확인"}
@@ -909,7 +909,7 @@ className="rounded-xl bg-black px-4 py-2 text-sm font-semibold text-white transi
                         <p className="text-sm text-slate-500">현재 발급된 카드가 없습니다.</p>
                         <Link
                           to="/card/nudgecard"
-className="mt-4 inline-flex rounded-xl bg-black px-4 py-3 text-sm font-semibold text-white transition hover:bg-gray-800"
+                          className="mt-4 inline-flex rounded-xl bg-black px-4 py-3 text-sm font-semibold transition hover:bg-gray-800"
                           style={{ color: "#ffffff" }}
                         >
                           카드 신청하러 가기

--- a/src/app/pages/loan/MyCreditScore.tsx
+++ b/src/app/pages/loan/MyCreditScore.tsx
@@ -101,6 +101,9 @@ export default function MyCreditScore() {
   const sectionToggleClass =
     "flex items-center justify-center p-0 text-slate-400 transition hover:text-slate-600";
   const sectionBodyClass = "mt-6 pl-6 pr-2";
+  const summaryLabelClass = "text-sm font-medium text-slate-500";
+  const summaryValueClass = "mt-4 break-keep text-xl font-bold tracking-tight text-slate-900 sm:text-2xl";
+  const summaryCaptionClass = "mt-2 text-sm text-slate-500";
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -118,41 +121,39 @@ export default function MyCreditScore() {
 
             <div className="mt-6 grid gap-4 sm:grid-cols-2 2xl:grid-cols-4">
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5 text-slate-900">
-                <p className="text-xs tracking-[0.12em] text-slate-500">내부 평가 점수</p>
-                <p className="mt-3 break-keep text-2xl font-semibold sm:text-3xl">
+                <p className={summaryLabelClass}>내부 평가 점수</p>
+                <p className={summaryValueClass}>
                   {isLoading ? "계산 중" : data ? `${data.creditScore}점` : "미평가"}
                 </p>
-                <p className="mt-2 text-sm text-slate-500">
+                <p className={summaryCaptionClass}>
                   {data ? "가장 최근 결과입니다." : "평가 후 점수가 표시됩니다."}
                 </p>
               </div>
 
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                <p className="text-sm font-medium text-slate-500">내부 평가 등급</p>
-                <p className="mt-4 break-keep text-xl font-bold text-slate-900 sm:text-2xl">
+                <p className={summaryLabelClass}>내부 평가 등급</p>
+                <p className={summaryValueClass}>
                   {isLoading ? "불러오는 중" : data?.creditGrade ?? "평가 대기"}
                 </p>
               </div>
 
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                <p className="text-sm font-medium text-slate-500">최근 변화</p>
-                <div className="mt-4 flex items-center gap-2">
-                  <p className="break-keep text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
-                    {isLoading
-                      ? "계산 중"
-                      : !data
-                        ? "미평가"
-                        : data.scoreChange === null
-                          ? "신규"
-                          : `${data.scoreChange > 0 ? "+" : ""}${data.scoreChange}점`}
-                  </p>
-                </div>
-                <p className="mt-2 text-sm text-slate-500">이전 결과와 비교한 변화입니다.</p>
+                <p className={summaryLabelClass}>최근 변화</p>
+                <p className={summaryValueClass}>
+                  {isLoading
+                    ? "계산 중"
+                    : !data
+                      ? "미평가"
+                      : data.scoreChange === null
+                        ? "신규"
+                        : `${data.scoreChange > 0 ? "+" : ""}${data.scoreChange}점`}
+                </p>
+                <p className={summaryCaptionClass}>이전 결과와 비교한 변화입니다.</p>
               </div>
 
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                <p className="text-sm font-medium text-slate-500">최근 평가일</p>
-                <p className="mt-4 text-lg font-bold leading-snug text-slate-900 sm:text-xl xl:text-2xl">
+                <p className={summaryLabelClass}>최근 평가일</p>
+                <p className={`${summaryValueClass} leading-snug`}>
                   {isLoading ? "계산 중" : data?.evaluatedAt ?? "평가 기록 없음"}
                 </p>
               </div>


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #181 

---

### 📝 작업 내용
- 마이페이지, 신용평가 페이지 글자색이랑 글자크기 조정

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 계정 페이지의 링크 및 버튼 텍스트 색상 처리 개선
  * 신용점수 페이지의 텍스트 스타일 일관성 강화 및 레이아웃 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->