### PR TITLE
Feat: 마크다운 링크 출력 색상 변경

### DIFF
--- a/src/app/components/MessageMarkdown.tsx
+++ b/src/app/components/MessageMarkdown.tsx
@@ -70,7 +70,7 @@ export default function MessageMarkdown({
               linkHref.startsWith("http://") || linkHref.startsWith("https://");
 
             if (isExternalLink) {
-              return <span>{children}</span>;
+              return null;
             }
 
             return (

--- a/src/app/components/MessageMarkdown.tsx
+++ b/src/app/components/MessageMarkdown.tsx
@@ -69,13 +69,15 @@ export default function MessageMarkdown({
             const isExternalLink =
               linkHref.startsWith("http://") || linkHref.startsWith("https://");
 
+            if (isExternalLink) {
+              return <span>{children}</span>;
+            }
+
             return (
               <a
                 href={linkHref}
-                target={isExternalLink ? "_blank" : undefined}
-                rel={isExternalLink ? "noreferrer" : undefined}
                 className={cn(
-                  "font-medium underline underline-offset-4",
+                  "font-medium text-blue-500 underline underline-offset-4 hover:text-blue-700",
                   disabledLinks ? "cursor-not-allowed opacity-60" : "cursor-pointer",
                 )}
                 onClick={(event) => {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #183 

---

### 📝 작업 내용
- 무엇을 / 왜 / 어떻게 수정했는지 간단히 작성

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 외부 마크다운 링크(http:// 또는 https://)가 클릭 불가능한 텍스트로 표시됩니다.

## 스타일
* 내부 링크의 스타일이 파란색 밑줄로 변경되었으며, 마우스 호버 시 색상이 변합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->