### PR TITLE
Refactor: 대출 상품에서 이미 가입한 상품 선택으로 관리 페이지 이동시 선택한 상품 구분 유지

### DIFF
--- a/src/app/pages/loan/LoanProducts.tsx
+++ b/src/app/pages/loan/LoanProducts.tsx
@@ -109,7 +109,7 @@ export default function LoanProducts() {
 
   const handleApply = (productId: string) => {
     if (isProductInUse(productId)) {
-      navigate("/loan/management");
+      navigate(`/loan/management?productKey=${productId}`);
       return;
     }
     navigate(`/loan/products/${productId}/apply`);

--- a/src/app/pages/loan/MyLoanManagement.tsx
+++ b/src/app/pages/loan/MyLoanManagement.tsx
@@ -304,6 +304,10 @@ export default function MyLoanManagement() {
     const parsedValue = Number(value);
     return Number.isFinite(parsedValue) ? parsedValue : null;
   }, [location.search]);
+  const productKeyFromQuery = useMemo(
+    () => new URLSearchParams(location.search).get("productKey"),
+    [location.search],
+  );
 
   const isApplicationOnOrAfterCompletedLoan = (
     application: LoanApplicationSummary,
@@ -468,6 +472,13 @@ export default function MyLoanManagement() {
     [applications, completedLoans],
   );
   const preferredProductKeyFromQuery = useMemo(() => {
+    if (
+      productKeyFromQuery &&
+      activeApplications.some((application) => application.productKey === productKeyFromQuery)
+    ) {
+      return productKeyFromQuery;
+    }
+
     if (repaymentTransactionIdFromQuery === null) {
       return null;
     }
@@ -475,7 +486,7 @@ export default function MyLoanManagement() {
     return activeApplications.some((application) => application.productKey === "consumption-loan")
       ? "consumption-loan"
       : null;
-  }, [activeApplications, repaymentTransactionIdFromQuery]);
+  }, [activeApplications, productKeyFromQuery, repaymentTransactionIdFromQuery]);
 
   useEffect(() => {
     if (activeApplications.length === 0) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #185 

---

### 📝 작업 내용
- 대출 상품에서 이미 가입한 상품 선택으로 관리 페이지 이동시 선택한 상품 구분 유지

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 이미 사용 중인 대출 상품 선택 시, 상품 정보를 포함하여 대출 관리 페이지로 이동하도록 개선되었습니다.
  * 대출 관리 페이지의 상품 선택 로직이 현재 활성 신청 정보와 쿼리 파라미터를 기반으로 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->